### PR TITLE
docs: architecture + running guide, fix README file map

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,24 +115,26 @@ names: ["car", "person", "bus", "traffic light", ...]
 
 ## 🚀 Quick Start  
 
-### 1. Launch the Flower Server  
+This project runs through the Flower simulation engine — one command launches the
+server and all simulated clients. Full details in [`docs/RUNNING.md`](docs/RUNNING.md).
+
+### 1. Install  
 ```bash  
-python server.py --num_rounds=10 --batch_size=32  
+cd my-project  
+pip install -e .  
 ```  
 
-### 2. Start Federated Clients  
-Open separate terminals for each client:  
+### 2. Run the federation  
 ```bash  
-# Client 0  
-python client.py --id=0 --data_path="data_clients/client_0/data.yaml"  
-
-# Client 1  
-python client.py --id=1 --data_path="data_clients/client_1/data.yaml"  
+flwr run .  
+# override config without editing pyproject.toml:  
+flwr run . --run-config "num_server_rounds=5 local_epochs=2"  
 ```  
 
 ### 3. Monitor Training  
-- **Server Logs**: Global model accuracy, round duration, client participation.  
-- **Client Logs**: Local training loss, validation mAP, GPU utilization.  
+Per-module logs land in `my-project/logs/` (`server.log`, `client.log`, `task.log`,
+`get_set.log`): round setup, batch-id assignment, weight checksums, and aggregated
+metrics (precision, recall, mAP).  
 
 ---
 
@@ -155,14 +157,19 @@ Use **Ctrl+C** in each terminal to stop the processes.
 
 ## 🏗️ Project Architecture  
 
-| File | Purpose |  
+> Run via Flower's app entrypoints (`cd my-project && flwr run .`), **not** standalone
+> scripts. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and
+> [`docs/RUNNING.md`](docs/RUNNING.md) for the full picture.
+
+| Path | Purpose |  
 |------|---------|  
-| `server.py` | Flower server for aggregating client updates. |  
-| `client.py` | Flower client to train YOLOv8 locally. |  
-| `simulation.py` | Runs multiple simulated FL clients on a single machine. |  
-| `train_config.py` | Configures training hyperparameters. |  
-| `split_clients.py` | Partitions dataset into client-specific subsets. |  
-| `label_utils.py` | Converts BDD100K annotations to YOLO format. |  
+| `my-project/pyproject.toml` | Flower app + federation config and hyperparameters (`[tool.flwr.app.config]`). |  
+| `my-project/my_project/server_app.py` | `ServerApp` + `CustomBatchStrategy` (FedAvg, batch-id assignment, aggregation). |  
+| `my-project/my_project/client_app.py` | `ClientApp` + `FlowerClient` that trains/evaluates YOLOv8 locally. |  
+| `my-project/my_project/task.py` | OS detection, model download, data.yaml path handling, dataset validation. |  
+| `my-project/my_project/get_set_model.py` | Converts weights between the YOLO model and NumPy arrays. |  
+| `my-project/utils/logging_setup.py` | Per-module file loggers under `logs/`. |  
+| `json_to_yolo/` | BDD100K JSON → YOLO label conversion. |  
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,96 @@
+# Architecture
+
+Federated object detection: **YOLOv8** (Ultralytics) trained across simulated
+clients with the **Flower** framework. Each client owns a different data shard
+(`batch_N`); only model weights — never images — cross the wire.
+
+## Runtime topology
+
+```
+                    flwr run  (Flower Simulation Engine)
+                              │
+                ┌─────────────┴─────────────┐
+                │     ServerApp (server_fn)  │
+                │  CustomBatchStrategy(FedAvg)│
+                │  - assigns unique batch_id  │
+                │  - aggregates weights       │
+                │  - tracks per-client OS     │
+                └─────────────┬─────────────┘
+          round: send global weights + {batch_id, local_epochs}
+                ┌─────────────┼─────────────┐
+                ▼             ▼             ▼
+          SuperNode 0    SuperNode 1    SuperNode 2     (num-supernodes)
+          ClientApp      ClientApp      ClientApp
+          (client_fn)    (client_fn)    (client_fn)
+          YOLO.train on  YOLO.train on  YOLO.train on
+          batch_<id>     batch_<id>     batch_<id>
+                │             │             │
+          return updated weights + metrics (mAP, precision, recall)
+                └─────────────┼─────────────┘
+                              ▼
+                   FedAvg weighted aggregation
+```
+
+## Federated round
+
+1. **Server → clients**: global weights + per-client config `{batch_id, local_epochs}`.
+   `CustomBatchStrategy.configure_fit` hands each client a *unique* `batch_id` so no
+   two clients train on the same shard in a round.
+2. **Client fit**: `set_weights` loads the global model, `YOLO.train` runs
+   `local_epochs` on `batch/batch_<id>/data.yaml`, `get_weights` extracts the result.
+3. **Clients → server**: updated weights + metrics (`precision`, `recall`, `mAP50`,
+   `mAP50-95`, `fitness`, `os`).
+4. **Aggregate**: `aggregate_fit` runs FedAvg (weighted by `num_examples`) and logs a
+   weight checksum so weight transport can be verified end-to-end.
+5. **Evaluate**: `configure_evaluate` → `YOLO.val` per client → `aggregate_evaluate`.
+
+Repeat for `num_server_rounds`.
+
+## Actual file map
+
+> The code runs through Flower's app entrypoints (`flwr run`), **not** standalone
+> `server.py` / `client.py` scripts.
+
+| Path | Role |
+|------|------|
+| `my-project/pyproject.toml` | Flower app + federation config; `[tool.flwr.app.config]` hyperparameters |
+| `my-project/my_project/server_app.py` | `ServerApp`, `server_fn`, `CustomBatchStrategy` (FedAvg + batch assignment + OS tracking) |
+| `my-project/my_project/client_app.py` | `ClientApp`, `client_fn`, `FlowerClient` (YOLO train/eval) |
+| `my-project/my_project/task.py` | OS detection, model download, data.yaml path handling, dataset validation, GPU batch-size heuristic |
+| `my-project/my_project/get_set_model.py` | `get_weights` / `set_weights` between YOLO `nn.Module` and NumPy arrays |
+| `my-project/utils/logging_setup.py` | Per-module file loggers under `logs/` |
+| `my-project/models/` | `yolov8s.pt` initial weights, `yolo8n.yaml` config |
+| `my-project/batch/batch_<id>/` | Per-client data shard (`data.yaml`, `images/`, `labels/`, split `.txt` files) |
+| `json_to_yolo/` | BDD100K JSON → YOLO label conversion notebooks/scripts |
+
+## Configuration
+
+Hyperparameters live in `my-project/pyproject.toml` under `[tool.flwr.app.config]`
+and are read by `server_fn` via `context.run_config`:
+
+| Key | Meaning |
+|-----|---------|
+| `num_server_rounds` | Number of FL rounds |
+| `fraction_fit` | Fraction of available clients sampled per round |
+| `local_epochs` | YOLO epochs each client runs per round |
+| `min_clients` | Minimum clients to start a round — **must be ≤ `num-supernodes`** |
+
+Federation sizing is under `[tool.flwr.federations.local-simulation]`
+(`num-supernodes`, per-client `num-cpus` / `num-gpus`). Override at runtime:
+
+```bash
+flwr run . --run-config "num_server_rounds=5 local_epochs=2"
+```
+
+## Class taxonomy (nc = 13)
+
+`person, rider, car, truck, bus, train, motorcycle, bicycle, traffic light,
+traffic sign, trailer, other person, other vehicle` — the BDD100K detection set.
+
+## Known constraints
+
+- Client `num_examples` is a placeholder (`10`); FedAvg weighting is therefore
+  uniform across clients regardless of true shard size.
+- `num-gpus` defaults to `0` (CPU-safe). Set to `1` per client only on a CUDA host.
+- `data.yaml` `path:` is rewritten to the local absolute path at runtime by
+  `task.update_data_yaml_paths` (handles the committed Windows path).

--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -1,0 +1,88 @@
+# Running the Simulation
+
+End-to-end steps to run the federated YOLOv8 training locally with Flower's
+simulation engine.
+
+## 1. Environment
+
+```bash
+conda create -n fl_yolov8 python=3.10 -y
+conda activate fl_yolov8
+
+# PyTorch (CUDA build shown; drop the index-url for CPU-only)
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+
+cd my-project
+pip install -e .          # installs flwr[simulation], ultralytics, etc. from pyproject.toml
+```
+
+## 2. Data layout
+
+Each client shard lives under `my-project/batch/batch_<id>/`:
+
+```
+batch/batch_1/
+├── data.yaml         # train/val/test + nc + class names
+├── images/           # train|val|test images
+├── labels/           # YOLO-format labels
+├── train.txt val.txt test.txt
+```
+
+`data.yaml` ships with a placeholder `path:`; `task.update_data_yaml_paths()`
+rewrites it to the correct local absolute path at runtime, so no manual edit is
+needed when moving machines.
+
+> Default `batch_id_range` is `(1, 10)` → expects `batch_1` … `batch_10`.
+
+## 3. Configure
+
+Edit `my-project/pyproject.toml`:
+
+```toml
+[tool.flwr.app.config]
+num_server_rounds = 2
+fraction_fit = 0.75
+local_epochs = 4
+min_clients = 3          # must be <= num-supernodes
+
+[tool.flwr.federations.local-simulation]
+options.num-supernodes = 3
+options.backend.client-resources.num-gpus = 0   # set 1 only on a CUDA host
+```
+
+## 4. Run
+
+```bash
+cd my-project
+flwr run .
+```
+
+Override config without editing the file:
+
+```bash
+flwr run . --run-config "num_server_rounds=5 local_epochs=2"
+```
+
+## 5. Observe
+
+Per-module logs are written under `my-project/logs/`:
+
+| Log | Content |
+|-----|---------|
+| `server.log` | round setup, batch-id assignment, weight checksums, aggregated metrics |
+| `client.log` | weight load, local train/val, per-client metrics |
+| `task.log` | model download, data.yaml path updates, dataset validation |
+| `get_set.log` | weight extract/apply + checksums |
+
+Weight checksums on both sides should match each round — that confirms weights
+actually transported and applied.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| Sim hangs "waiting for clients" | `min_clients` > `num-supernodes`. Lower `min_clients`. |
+| `RuntimeError: CUDA ...` / no GPU | Set `num-gpus = 0` in both `client-resources` and `init_args`. |
+| `Missing training data.yaml` | `batch_<id>` shard absent or `batch_id_range` mismatched. |
+| Parameter count / shape mismatch | Client and server must load the **same** YOLO arch (`yolov8s`). |
+| Model download fails | `task.download_model` pulls `yolov8s.pt`; pre-place it in `models/` if offline. |


### PR DESCRIPTION
## Problem
README's architecture table and Quick Start listed files that do not exist (`server.py`, `client.py`, `simulation.py`, `split_clients.py`, `label_utils.py`). The project runs through Flower app entrypoints (`flwr run`), so the docs misled anyone onboarding.

## Changes
- **`docs/ARCHITECTURE.md`** — runtime topology diagram, federated-round walkthrough, accurate file map, config reference (`run_config` keys), known constraints.
- **`docs/RUNNING.md`** — environment setup, data layout, configuration, run commands, log/observability guide, troubleshooting table.
- **`README.md`** — replace fictional file table with the real module map; rewrite Quick Start to `flwr run .` with `--run-config` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)