### PR TITLE
feat: per-round metrics CSV + run summary

### DIFF
--- a/my-project/my_project/server_app.py
+++ b/my-project/my_project/server_app.py
@@ -20,6 +20,7 @@ from my_project.task import download_model, IS_WINDOWS, OS_NAME
 from my_project.get_set_model import get_weights, set_weights
 
 from utils.logging_setup import configure_logging
+from utils.metrics_logger import MetricsLogger, aggregate_client_metrics
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 logger = configure_logging("server", "logs/server.log")
@@ -60,6 +61,7 @@ class CustomBatchStrategy(FedAvg):
         fit_metrics_aggregation_fn: Optional[Any] = None,
         evaluate_metrics_aggregation_fn: Optional[Any] = None,
         batch_id_range: tuple = DEFAULT_BATCH_ID_RANGE,
+        num_rounds: int = DEFAULT_NUM_ROUNDS,
     ):
         super().__init__(
             fraction_fit=fraction_fit,
@@ -80,6 +82,8 @@ class CustomBatchStrategy(FedAvg):
         self.used_batch_ids = set()
         self.client_to_batch_id: Dict[str, int] = {}
         self.client_os_info: Dict[str, str] = {}  # Track client OS information
+        self.num_rounds = num_rounds
+        self.metrics_logger = MetricsLogger()  # writes logs/metrics.csv
         logger.info(f"[Server] CustomBatchStrategy initialized with batch_id_range={batch_id_range}")
     
     def _get_unused_batch_id(self, client_id: str) -> int:
@@ -254,7 +258,11 @@ class CustomBatchStrategy(FedAvg):
         
         # Log results and failures
         logger.info(f"[Server] Aggregating {len(results)} fit results and {len(failures)} failures")
-        
+
+        # Persist a weighted-average of client training metrics for this round.
+        fit_metrics = aggregate_client_metrics(results)
+        self.metrics_logger.log_round(server_round, "fit", fit_metrics, num_clients=len(results))
+
         # Call the parent's aggregation method
         parameters, metrics = super().aggregate_fit(server_round, results, failures)
         
@@ -310,9 +318,19 @@ class CustomBatchStrategy(FedAvg):
                 self.client_os_info[client_proxy.cid] = client_os
                 logger.info(f"[Server] Client {client_proxy.cid} evaluated on {client_os}")
         
+        # Persist a weighted-average of client evaluation metrics for this round.
+        eval_metrics = aggregate_client_metrics(results)
+
         # Call the parent's aggregation method
         loss, metrics = super().aggregate_evaluate(server_round, results, failures)
-        
+
+        self.metrics_logger.log_round(
+            server_round, "evaluate", eval_metrics, num_clients=len(results), loss=loss
+        )
+        # Emit the run summary once the final round has been evaluated.
+        if server_round >= self.num_rounds:
+            self.metrics_logger.summary()
+
         # Add OS information to metrics
         metrics["server_os"] = OS_NAME
         
@@ -360,7 +378,8 @@ def server_fn(_):
         min_fit_clients=2,       # Minimum clients needed for training
         min_available_clients=2, # Minimum clients needed to start FL (consistent with min_fit_clients)
         initial_parameters=fl.common.ndarrays_to_parameters(initial_weights),
-        batch_id_range=DEFAULT_BATCH_ID_RANGE
+        batch_id_range=DEFAULT_BATCH_ID_RANGE,
+        num_rounds=DEFAULT_NUM_ROUNDS,
     )
 
     # Configure server

--- a/my-project/utils/metrics_logger.py
+++ b/my-project/utils/metrics_logger.py
@@ -1,0 +1,92 @@
+"""Per-round federated metrics logging to CSV plus an end-of-run summary.
+
+The Flower strategy calls into this module from ``aggregate_fit`` /
+``aggregate_evaluate`` to persist a row per round/stage to ``logs/metrics.csv``
+and to emit a best-mAP summary when the final round completes.
+"""
+import csv
+import os
+from pathlib import Path
+
+from utils.logging_setup import configure_logging
+
+logger = configure_logging("metrics", "logs/metrics.log")
+
+# Metric keys reported by YOLO clients (see client_app.py).
+METRIC_KEYS = ["precision", "recall", "mAP50", "mAP50-95", "fitness"]
+
+
+def aggregate_client_metrics(results):
+    """Weighted average of client metrics, weighted by ``num_examples``.
+
+    Args:
+        results: list of ``(client_proxy, res)`` where ``res`` has ``num_examples``
+                 and a ``metrics`` dict.
+
+    Returns:
+        dict mapping each METRIC_KEYS entry to its weighted mean (0.0 if no data).
+    """
+    acc = {k: 0.0 for k in METRIC_KEYS}
+    total = 0
+    for _, res in results:
+        n = int(getattr(res, "num_examples", 0) or 0)
+        if n <= 0:
+            n = 1
+        metrics = getattr(res, "metrics", {}) or {}
+        for k in METRIC_KEYS:
+            try:
+                acc[k] += float(metrics.get(k, 0.0)) * n
+            except (TypeError, ValueError):
+                pass
+        total += n
+    if total == 0:
+        return {k: 0.0 for k in METRIC_KEYS}
+    return {k: acc[k] / total for k in acc}
+
+
+class MetricsLogger:
+    """Append per-round metrics to a CSV and log a final summary."""
+
+    def __init__(self, csv_path="logs/metrics.csv"):
+        self.csv_path = csv_path
+        self.fieldnames = ["round", "stage", "num_clients", "loss"] + METRIC_KEYS
+        self.history = []
+        Path(os.path.dirname(csv_path) or ".").mkdir(parents=True, exist_ok=True)
+        # Fresh header each run so stale rows don't pile up across runs.
+        with open(self.csv_path, "w", newline="") as f:
+            csv.DictWriter(f, fieldnames=self.fieldnames).writeheader()
+        logger.info(f"[Metrics] logging per-round metrics to {self.csv_path}")
+
+    def log_round(self, server_round, stage, metrics, num_clients, loss=None):
+        """Write one row for (round, stage) and remember it for the summary."""
+        row = {
+            "round": server_round,
+            "stage": stage,
+            "num_clients": num_clients,
+            "loss": None if loss is None else round(float(loss), 5),
+        }
+        for k in METRIC_KEYS:
+            try:
+                row[k] = round(float(metrics.get(k, 0.0)), 5)
+            except (TypeError, ValueError):
+                row[k] = 0.0
+        with open(self.csv_path, "a", newline="") as f:
+            csv.DictWriter(f, fieldnames=self.fieldnames).writerow(row)
+        self.history.append(row)
+        logger.info(f"[Metrics] round={server_round} stage={stage} -> {row}")
+
+    def summary(self):
+        """Log best-mAP50 across rounds (prefers evaluate rows)."""
+        evals = [r for r in self.history if r["stage"] == "evaluate"]
+        rows = evals or self.history
+        if not rows:
+            logger.info("[Metrics] no data collected; skipping summary.")
+            return
+        best = max(rows, key=lambda r: r.get("mAP50", 0.0))
+        num_rounds = len({r["round"] for r in self.history})
+        logger.info(
+            f"[Metrics] === SUMMARY === rounds={num_rounds} | "
+            f"best mAP50={best['mAP50']} @ round {best['round']} ({best['stage']}) | "
+            f"precision={best['precision']} recall={best['recall']} "
+            f"mAP50-95={best['mAP50-95']} | CSV: {self.csv_path}"
+        )


### PR DESCRIPTION
## What
Adds machine-readable, aggregated FL metrics on top of the existing text logs.

- **`utils/metrics_logger.py`**
  - `MetricsLogger` → writes `logs/metrics.csv` with `round, stage, num_clients, loss, precision, recall, mAP50, mAP50-95, fitness`, and logs a best-`mAP50` summary at the end.
  - `aggregate_client_metrics` → `num_examples`-weighted mean of client metrics (the base FedAvg has no metrics-aggregation fn, so these were previously lost).
- **`CustomBatchStrategy`** logs `fit` and `evaluate` rows each round; emits the summary once the final round is evaluated.

## Test
Unit-tested the logger standalone (no flwr needed): weighted average correct (`0.5·10 + 0.9·30 / 40 = 0.8`), CSV rows + summary verified. `py_compile` passes.

> Note: overlaps `server_app.py` with #16; merge order may need a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)