### PR TITLE
feat: config-selectable FedProx proximal regularization

### DIFF
--- a/docs/FEDPROX.md
+++ b/docs/FEDPROX.md
@@ -1,0 +1,63 @@
+# FedProx Strategy
+
+Optional FedProx-style proximal regularization on top of the FedAvg baseline,
+selectable from config. Motivated by Roadmap item #1 — BDD100K shards are
+**non-IID** (different scenes/time-of-day per client), where plain FedAvg can
+diverge as local models drift apart.
+
+## Why FedProx
+
+FedProx ([Li et al., 2020](https://arxiv.org/abs/1812.06127)) adds a proximal
+term to each client's objective:
+
+```
+min_w  F_k(w) + (mu/2) * || w - w_global ||^2
+```
+
+The `(mu/2)||w - w_global||²` term penalizes local models for straying far from
+the global model, which stabilizes training under heterogeneous (non-IID) data
+and partial participation.
+
+## How it's implemented here
+
+True FedProx adds the proximal term to the loss at **every SGD step**. This
+project trains via Ultralytics' high-level `YOLO.train()`, which does not expose
+a per-step loss hook. So the proximal term is applied as a **round-level
+approximation in weight space**, after local training completes:
+
+```
+w_client  ←  w_client − mu · (w_client − w_global)
+```
+
+i.e. each client's update is shrunk toward the global model by factor `mu`
+before being sent back for aggregation. `mu = 0` is exactly FedAvg; larger `mu`
+pulls harder toward the global model.
+
+- **Server** (`server_app.py`): `server_fn` reads `strategy` / `proximal_mu`
+  from `run_config`; `CustomBatchStrategy` ships `proximal_mu` to clients in the
+  fit config. Aggregation stays FedAvg (FedProx uses FedAvg aggregation).
+- **Client** (`client_app.py`): snapshots the global weights, trains locally,
+  then applies the shrinkage above when `proximal_mu > 0`.
+
+> This is a pragmatic approximation, not per-step FedProx. For exact FedProx,
+> swap in a custom Ultralytics trainer that adds the proximal term to the loss.
+
+## Usage
+
+Enable via `pyproject.toml`:
+
+```toml
+[tool.flwr.app.config]
+strategy = "fedprox"
+proximal_mu = 0.1
+```
+
+Or at runtime without editing the file:
+
+```bash
+flwr run . --run-config "strategy='fedprox' proximal_mu=0.1"
+```
+
+Typical `mu` values: `0.001`–`1.0`. Start at `0.1`; raise it if clients diverge,
+lower it if convergence stalls. Clients that applied the term report
+`proximal_mu` in their fit metrics.

--- a/my-project/my_project/client_app.py
+++ b/my-project/my_project/client_app.py
@@ -131,9 +131,14 @@ class FlowerClient(Client):
                 status=Status(code=Code.FIT_NOT_IMPLEMENTED, message="Failed to load weights for training"),
             )
 
+        # Snapshot the global weights so we can apply a FedProx proximal pull
+        # after local training (see step 6).
+        global_weights = [w.copy() for w in weights_list]
+
         # 2) Parse config from server
         batch_id = ins.config.get("batch_id", None)
         local_epochs = ins.config.get("local_epochs", self.local_epochs)
+        proximal_mu = float(ins.config.get("proximal_mu", 0.0))
 
         # Use stored batch_id as fallback if available
         if batch_id is None:
@@ -199,6 +204,20 @@ class FlowerClient(Client):
 
             # 6) Extract updated weights for sending back to server
             updated_weights = get_weights(self.model)
+
+            # FedProx: pull the locally-trained weights back toward the global model
+            # by factor mu, i.e. w <- w - mu * (w - w_global). mu == 0 is plain FedAvg.
+            # This is a round-level approximation of the FedProx proximal term, applied
+            # in weight space because Ultralytics' high-level trainer does not expose a
+            # per-step loss hook. See docs/FEDPROX.md.
+            if proximal_mu > 0 and len(updated_weights) == len(global_weights):
+                logger.info(f"[Client] Applying FedProx proximal term (mu={proximal_mu}).")
+                updated_weights = [
+                    w - proximal_mu * (w - g)
+                    for w, g in zip(updated_weights, global_weights)
+                ]
+                metrics["proximal_mu"] = proximal_mu
+
             updated_checksum = sum(w.sum() for w in updated_weights if w.size > 0)
             logger.info(f"[Client] Sending back weights with checksum: {updated_checksum}")
             

--- a/my-project/my_project/server_app.py
+++ b/my-project/my_project/server_app.py
@@ -60,6 +60,7 @@ class CustomBatchStrategy(FedAvg):
         fit_metrics_aggregation_fn: Optional[Any] = None,
         evaluate_metrics_aggregation_fn: Optional[Any] = None,
         batch_id_range: tuple = DEFAULT_BATCH_ID_RANGE,
+        proximal_mu: float = 0.0,
     ):
         super().__init__(
             fraction_fit=fraction_fit,
@@ -80,7 +81,13 @@ class CustomBatchStrategy(FedAvg):
         self.used_batch_ids = set()
         self.client_to_batch_id: Dict[str, int] = {}
         self.client_os_info: Dict[str, str] = {}  # Track client OS information
-        logger.info(f"[Server] CustomBatchStrategy initialized with batch_id_range={batch_id_range}")
+        # proximal_mu > 0 turns on FedProx-style proximal regularization on clients.
+        self.proximal_mu = float(proximal_mu)
+        strategy_name = "FedProx" if self.proximal_mu > 0 else "FedAvg"
+        logger.info(
+            f"[Server] CustomBatchStrategy initialized with batch_id_range={batch_id_range}, "
+            f"strategy={strategy_name} (proximal_mu={self.proximal_mu})"
+        )
     
     def _get_unused_batch_id(self, client_id: str) -> int:
         """
@@ -156,6 +163,9 @@ class CustomBatchStrategy(FedAvg):
                 # Insert it into the config
                 fit_config["batch_id"] = batch_id
                 fit_config["local_epochs"] = 1
+                # Tell the client how strongly to pull local weights back toward the
+                # global model (0.0 => plain FedAvg, no proximal term).
+                fit_config["proximal_mu"] = self.proximal_mu
 
                 logger.info(
                     f"[Server] Assigning batch_id={batch_id} "
@@ -336,6 +346,16 @@ def server_fn(_):
     """
     logger.info("[Server] Initializing YOLO model for FL...")
 
+    # Strategy selection from run_config: strategy = "fedavg" | "fedprox".
+    run_config = getattr(_, "run_config", {}) or {}
+    strategy_name = str(run_config.get("strategy", "fedavg")).lower()
+    proximal_mu = float(run_config.get("proximal_mu", 0.0))
+    if strategy_name == "fedprox" and proximal_mu <= 0:
+        proximal_mu = 0.1  # sensible default when FedProx is requested without a mu
+    if strategy_name != "fedprox":
+        proximal_mu = 0.0  # force plain FedAvg
+    logger.info(f"[Server] Strategy={strategy_name}, proximal_mu={proximal_mu}")
+
     # Check if model exists, otherwise download
     if not os.path.exists(MODEL_PATH):
         logger.info(f"[Server] Model not found at {MODEL_PATH}, downloading...")
@@ -360,7 +380,8 @@ def server_fn(_):
         min_fit_clients=2,       # Minimum clients needed for training
         min_available_clients=2, # Minimum clients needed to start FL (consistent with min_fit_clients)
         initial_parameters=fl.common.ndarrays_to_parameters(initial_weights),
-        batch_id_range=DEFAULT_BATCH_ID_RANGE
+        batch_id_range=DEFAULT_BATCH_ID_RANGE,
+        proximal_mu=proximal_mu,
     )
 
     # Configure server

--- a/my-project/pyproject.toml
+++ b/my-project/pyproject.toml
@@ -32,6 +32,8 @@ num_server_rounds = 2
 fraction_fit = 0.75
 local_epochs = 4
 min_clients = 5  # Ensures clarity on the required minimum clients
+strategy = "fedavg"   # "fedavg" or "fedprox"
+proximal_mu = 0.0     # FedProx proximal strength; >0 enables FedProx (default 0.1 if strategy=fedprox)
 
 
 [tool.flwr.federations]


### PR DESCRIPTION
## What
Roadmap #1. Optional FedProx-style proximal regularization over the FedAvg baseline, selectable from config. BDD100K shards are non-IID, where FedAvg can diverge; FedProx penalizes local drift from the global model.

## How
- **`pyproject.toml`** — new `strategy` (`fedavg`|`fedprox`) and `proximal_mu` config keys.
- **`server_app.py`** — `server_fn` reads `strategy`/`proximal_mu` from `run_config`; `CustomBatchStrategy` ships `proximal_mu` to clients in the fit config (aggregation stays FedAvg, as FedProx specifies).
- **`client_app.py`** — snapshots global weights, trains, then applies `w ← w − mu·(w − w_global)` when `mu > 0`.
- **`docs/FEDPROX.md`** — rationale + the approximation note + usage.

## Note on fidelity
True FedProx adds the proximal term to the loss every SGD step. Ultralytics' high-level `YOLO.train()` exposes no per-step loss hook, so this applies the proximal pull **at round level in weight space** — a documented approximation. Exact FedProx would need a custom Ultralytics trainer.

## Usage
```bash
flwr run . --run-config "strategy='fedprox' proximal_mu=0.1"
```

## Test
`py_compile` passes; proximal formula verified by hand (`mu=0`→FedAvg, `mu=1`→global).

> Overlaps `server_app.py`/`pyproject.toml` with #16 and #19; merge order may need trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)