### PR TITLE
fix: transfer full state_dict incl. BatchNorm buffers (correct FedAvg)

### DIFF
--- a/my-project/my_project/get_set_model.py
+++ b/my-project/my_project/get_set_model.py
@@ -4,8 +4,11 @@ import torch
 import numpy as np
 import platform
 import os
-from ultralytics import YOLO
 from collections import OrderedDict
+# NOTE: ultralytics (YOLO) is imported lazily inside load_yolo_model() so that the
+# core weight-transfer helpers (get_weights/set_weights) depend only on torch +
+# numpy. This keeps FedAvg serialization testable and importable without the heavy
+# ultralytics dependency.
 from utils.logging_setup import configure_logging
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -36,23 +39,38 @@ def get_normalized_path(path):
 
 def get_weights(model):
     """
-    Extract YOLOv8 model weights as a list of NumPy arrays.
-    
+    Extract the FULL model state as a list of NumPy arrays, in ``state_dict`` order.
+
+    Unlike ``model.parameters()`` (learnable tensors only), ``state_dict()`` also
+    includes registered buffers — crucially the BatchNorm running statistics
+    (``running_mean``, ``running_var``, ``num_batches_tracked``). YOLOv8 is
+    BatchNorm-heavy, so transferring only parameters means FedAvg never averages
+    those statistics and the federated model is incorrect. We therefore serialize
+    the whole ``state_dict``.
+
+    Order: ``state_dict()`` preserves a deterministic insertion order for a fixed
+    module structure, so the i-th array here corresponds to the i-th key of
+    ``model.state_dict().keys()`` on any process that builds the same architecture.
+    Only the ordered arrays travel over the wire; keys are reconstructed locally in
+    ``set_weights`` (see its invariant note).
+
     Args:
-        model: A loaded YOLOv8 model instance (DetectionModel).
-    
+        model: A loaded YOLOv8 model instance (DetectionModel / nn.Module).
+
     Returns:
-        A list of NumPy arrays representing each parameter tensor, or empty list on error.
+        A list of NumPy arrays (one per state_dict entry), or empty list on error.
     """
     try:
-        logger.debug("[GetSet] Extracting YOLOv8 model weights...")
-        # The model is now a DetectionModel object, not a dictionary
-        weights_list = [param.detach().cpu().numpy() for param in model.parameters()]
-        
-        # Calculate checksum for debugging
+        logger.debug("[GetSet] Extracting YOLOv8 model state_dict (params + buffers)...")
+        weights_list = [t.detach().cpu().numpy() for t in model.state_dict().values()]
+
+        # Calculate checksum for debugging weight transport.
         weights_checksum = sum(w.sum() for w in weights_list if w.size > 0)
-        
-        logger.debug(f"[GetSet] Extracted {len(weights_list)} weight tensors with checksum: {weights_checksum}")
+
+        logger.debug(
+            f"[GetSet] Extracted {len(weights_list)} state tensors "
+            f"(params+buffers) with checksum: {weights_checksum}"
+        )
         return weights_list
     except Exception as e:
         logger.error(f"[GetSet] get_weights error: {e}", exc_info=True)
@@ -61,44 +79,60 @@ def get_weights(model):
 
 def set_weights(model, parameters: List[np.ndarray]) -> bool:
     """
-    Apply weights to YOLOv8 model parameters.
-    
+    Apply a full ``state_dict`` (params + buffers) received as ordered NumPy arrays.
+
+    The incoming list is zipped, in order, against ``model.state_dict().keys()``
+    recomputed locally, rebuilt into an ``OrderedDict``, and loaded with
+    ``load_state_dict(..., strict=True)``.
+
+    **Invariant:** both the server and every client must construct the *identical*
+    architecture (``YOLO("models/yolov8s.pt").model`` with ``nc=13``) before calling
+    this. Then the local key order matches the order ``get_weights`` used on the
+    sender, so positional zip is correct. ``strict=True`` raises loudly if the order
+    or set of keys ever drifts — the desired failure mode, not a silent partial load.
+
+    Each integer buffer (notably BatchNorm ``num_batches_tracked``, int64) is cast
+    back to the model's own dtype/device for that key, so ``load_state_dict``'s dtype
+    check passes (a raw ``from_numpy`` of an int array would otherwise mismatch).
+
     Args:
-        model: The YOLOv8 model instance
-        parameters: List of NumPy arrays with weights
-        
+        model: The YOLOv8 model instance.
+        parameters: Ordered list of NumPy arrays (full state_dict).
+
     Returns:
-        bool: True on success, False on error
+        bool: True on success, False on error.
     """
     try:
-        logger.debug("[GetSet] Setting YOLOv8 model weights...")
-        
-        # Calculate checksum for debugging
+        logger.debug("[GetSet] Setting YOLOv8 model state_dict (params + buffers)...")
+
+        # Calculate checksum for debugging.
         weights_checksum = sum(w.sum() for w in parameters if w.size > 0)
-        logger.debug(f"[GetSet] Applying weights with checksum: {weights_checksum}")
-        
-        # Validate parameter length
-        model_params = list(model.parameters())
-        if len(parameters) != len(model_params):
-            logger.error(f"[GetSet] Parameter count mismatch: model has {len(model_params)} layers, but received {len(parameters)} arrays")
+        logger.debug(f"[GetSet] Applying state with checksum: {weights_checksum}")
+
+        ref_state = model.state_dict()
+        keys = list(ref_state.keys())
+        if len(parameters) != len(keys):
+            logger.error(
+                f"[GetSet] State count mismatch: model has {len(keys)} state tensors, "
+                f"but received {len(parameters)} arrays. "
+                f"(Are server and client building the same architecture?)"
+            )
             return False
-        
-        # Apply weights to each layer
-        for i, param in enumerate(model_params):
-            param_ = torch.from_numpy(parameters[i]).to(param.device)
-            
-            # Check shape compatibility
-            if param_.shape != param.shape:
+
+        new_state = OrderedDict()
+        for key, arr in zip(keys, parameters):
+            ref = ref_state[key]
+            tensor = torch.as_tensor(arr).to(dtype=ref.dtype, device=ref.device)
+            if tensor.shape != ref.shape:
                 logger.error(
-                    f"[GetSet] Shape mismatch at parameter {i}: "
-                    f"model shape {param.shape} != parameter shape {param_.shape}"
+                    f"[GetSet] Shape mismatch at '{key}': "
+                    f"model {tuple(ref.shape)} != received {tuple(tensor.shape)}"
                 )
                 return False
-                
-            # Copy the weights
-            param.data.copy_(param_)
-            
-        logger.debug("[GetSet] Model weights updated successfully.")
+            new_state[key] = tensor
+
+        model.load_state_dict(new_state, strict=True)
+        logger.debug("[GetSet] Model state_dict updated successfully.")
         return True
     except Exception as e:
         logger.error(f"[GetSet] Error in set_weights: {e}", exc_info=True)
@@ -118,6 +152,8 @@ def load_yolo_model(yaml_path="models/yolo8n.yaml",
         The loaded model or None on error
     """
     try:
+        from ultralytics import YOLO  # lazy import; see module header note
+
         # Normalize paths for current OS
         yaml_path = get_normalized_path(yaml_path)
         weight_path = get_normalized_path(weight_path)

--- a/my-project/tests/test_weights.py
+++ b/my-project/tests/test_weights.py
@@ -1,0 +1,99 @@
+"""Weight-transfer correctness tests for get_set_model.
+
+These prove the FedAvg-critical property: a get_weights -> set_weights round-trip
+restores the FULL model state, including BatchNorm running buffers — not just the
+learnable parameters. A toy BatchNorm-containing module is used so the tests run
+without downloading the full YOLOv8 model (a YOLO-specific check lives in the
+integration tests / conftest model fixture).
+"""
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn
+
+from my_project.get_set_model import get_weights, set_weights
+
+
+class TinyBNNet(nn.Module):
+    """Conv + BatchNorm + Linear: has params AND BN buffers, like YOLO blocks."""
+
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 4, kernel_size=3, padding=1)
+        self.bn = nn.BatchNorm2d(4)
+        self.fc = nn.Linear(4, 2)
+
+    def forward(self, x):
+        x = self.bn(self.conv(x))
+        return self.fc(x.mean(dim=(2, 3)))
+
+
+def _train_a_step(model):
+    """Run a forward/backward in train mode so BN buffers diverge from defaults."""
+    model.train()
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    x = torch.randn(8, 3, 8, 8)
+    out = model(x)
+    out.sum().backward()
+    opt.step()
+    # Several forward passes update running_mean/var and num_batches_tracked.
+    for _ in range(3):
+        model(torch.randn(8, 3, 8, 8))
+
+
+def test_state_dict_includes_buffers():
+    """get_weights must serialize the whole state_dict, strictly more than params."""
+    model = TinyBNNet()
+    n_state = len(get_weights(model))
+    n_params = len(list(model.parameters()))
+    assert n_state == len(model.state_dict())
+    assert n_state > n_params, (
+        "get_weights returned only parameters — BatchNorm buffers are missing, "
+        "which breaks FedAvg correctness."
+    )
+
+
+def test_weight_roundtrip_restores_bn_buffers():
+    """A full round-trip restores every state tensor incl. BN running stats."""
+    src = TinyBNNet()
+    _train_a_step(src)  # make BN buffers non-trivial
+
+    # Sanity: source BN running_mean is no longer the default zeros.
+    assert not torch.allclose(src.bn.running_mean, torch.zeros_like(src.bn.running_mean))
+
+    weights = get_weights(src)
+
+    dst = TinyBNNet()  # fresh model with default buffers
+    assert not torch.allclose(dst.bn.running_mean, src.bn.running_mean)
+
+    ok = set_weights(dst, weights)
+    assert ok is True
+
+    # Every tensor in the state dict must match after the round-trip.
+    for key, src_t in src.state_dict().items():
+        dst_t = dst.state_dict()[key]
+        assert dst_t.dtype == src_t.dtype, f"dtype drift at {key}"
+        assert torch.allclose(dst_t.float(), src_t.float()), f"value drift at {key}"
+
+    # num_batches_tracked is an int64 buffer — confirm it stayed integer and equal.
+    assert dst.bn.num_batches_tracked.dtype == torch.int64
+    assert int(dst.bn.num_batches_tracked) == int(src.bn.num_batches_tracked)
+
+
+def test_set_weights_length_mismatch_returns_false():
+    """Wrong-length input must fail safely (False), not partially load."""
+    model = TinyBNNet()
+    weights = get_weights(model)
+    assert set_weights(model, weights[:-1]) is False
+
+
+def test_roundtrip_through_numpy_list():
+    """Weights must survive as a plain list of numpy arrays (the wire format)."""
+    src = TinyBNNet()
+    _train_a_step(src)
+    weights = get_weights(src)
+    assert all(isinstance(w, np.ndarray) for w in weights)
+    dst = TinyBNNet()
+    assert set_weights(dst, [w.copy() for w in weights]) is True
+    assert torch.allclose(dst.bn.running_var, src.bn.running_var)


### PR DESCRIPTION
## The real federated-learning bug
`get_weights`/`set_weights` used `model.parameters()`, which excludes BatchNorm **buffers** (`running_mean`, `running_var`, `num_batches_tracked`). YOLOv8 is BatchNorm-heavy, so FedAvg aggregated only ~half the model state — the running statistics each client uses for inference were **never averaged across the federation**. This is what made "transfer the weight and work like federated learning" not actually hold.

## Fix
- `get_weights` → serialize the full `state_dict().values()` (params + buffers).
- `set_weights` → zip the incoming ordered arrays against locally-recomputed `state_dict().keys()` into an `OrderedDict`, cast each tensor to the model's own dtype/device (so int64 `num_batches_tracked` restores as int), then `load_state_dict(strict=True)`.
- **Invariant** (documented): server and clients build the identical arch before loading; `strict=True` fails loudly if key order ever drifts.
- Made the `ultralytics` import lazy so the core weight helpers depend only on torch+numpy (and are unit-testable).

## Verification (real torch 2.x CPU)
`pytest tests/test_weights.py` → **4 passed**:
- round-trip restores BN running stats (perturbed then recovered, dtype preserved)
- `len(get_weights) == len(state_dict) > len(parameters)` (regression guard)
- length mismatch fails safe (returns False, no partial load)
- numpy-list wire format survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)