### PR TITLE
fix: weight FedAvg by real shard size (num_examples)

### DIFF
--- a/my-project/my_project/client_app.py
+++ b/my-project/my_project/client_app.py
@@ -9,10 +9,11 @@ from flwr.common import Context, FitIns, FitRes, EvaluateIns, EvaluateRes, Param
 
 from ultralytics import YOLO
 from my_project.task import (
-    download_model, 
-    get_data_yaml_path, 
-    update_data_yaml_paths, 
-    IS_WINDOWS, 
+    download_model,
+    get_data_yaml_path,
+    update_data_yaml_paths,
+    count_shard_examples,
+    IS_WINDOWS,
     OS_NAME
 )  # Import OS detection
 import urllib
@@ -183,7 +184,8 @@ class FlowerClient(Client):
             
             # 5) Process results
             if hasattr(results, "results_dict"):
-                num_examples = 10  # Default value if exact count is not available
+                # Real shard size → FedAvg aggregation weight proportional to data.
+                num_examples = count_shard_examples(self.batch_id, "train")
                 results_dict = results.results_dict
                 
                 # Create metrics dictionary
@@ -315,7 +317,8 @@ class FlowerClient(Client):
             )
             
             # 6) Process results
-            num_examples = 10  # Default value if exact count is not available
+            # Real val-shard size → correct weighting of the aggregated loss.
+            num_examples = count_shard_examples(self.batch_id, "val")
             fitness_value = results.results_dict.get("fitness", float("inf"))
             
             # Create metrics dictionary

--- a/my-project/my_project/task.py
+++ b/my-project/my_project/task.py
@@ -1,3 +1,5 @@
+from __future__ import annotations  # lazy annotations: YOLO type hints need no import
+
 import os
 import logging
 import warnings
@@ -8,7 +10,9 @@ import platform
 import sys
 from pathlib import Path
 from collections import OrderedDict
-from ultralytics import YOLO
+# ultralytics (YOLO) is only referenced in type hints below; with future
+# annotations it is never evaluated at import time, so dataset/path helpers like
+# count_shard_examples stay importable without the heavy ultralytics dependency.
 
 from utils.logging_setup import configure_logging
 
@@ -91,6 +95,50 @@ def get_data_yaml_path(batch_id):
         Path: Path to the data.yaml file
     """
     return get_batch_path(batch_id) / "data.yaml"
+
+
+def count_shard_examples(batch_id, split="train"):
+    """
+    Count the number of examples in a client's data shard for a given split.
+
+    FedAvg weights each client's update by ``num_examples``; reporting a real
+    count (instead of a constant) makes aggregation correctly proportional to
+    shard size. Primary source is the split list file (``train.txt`` / ``val.txt``
+    / ``test.txt``, one image per line); falls back to counting image files under
+    ``images/<split>/`` if the list file is absent.
+
+    Args:
+        batch_id: The batch ID.
+        split: "train", "val", or "test".
+
+    Returns:
+        int: Number of examples (>= 1, so a client never gets zero weight).
+    """
+    base = get_batch_path(batch_id)
+
+    # Primary: count non-empty lines in the split list file.
+    list_file = base / f"{split}.txt"
+    if list_file.exists():
+        try:
+            with open(list_file, "r") as f:
+                count = sum(1 for line in f if line.strip())
+            if count > 0:
+                logger.debug(f"[Task] batch {batch_id} {split}: {count} examples (from {list_file.name})")
+                return count
+        except Exception as e:
+            logger.warning(f"[Task] Failed reading {list_file}: {e}; falling back to file count.")
+
+    # Fallback: count image files under images/<split>/.
+    img_dir = base / "images" / split
+    if img_dir.exists():
+        exts = {".jpg", ".jpeg", ".png", ".bmp"}
+        count = sum(1 for p in img_dir.iterdir() if p.suffix.lower() in exts)
+        logger.debug(f"[Task] batch {batch_id} {split}: {count} examples (from {img_dir})")
+        if count > 0:
+            return count
+
+    logger.warning(f"[Task] Could not count examples for batch {batch_id} split {split}; defaulting to 1.")
+    return 1
 
 def update_data_yaml_paths(batch_id):
     """

--- a/my-project/tests/test_num_examples.py
+++ b/my-project/tests/test_num_examples.py
@@ -1,0 +1,25 @@
+"""Tests that num_examples reflects real shard size (FedAvg aggregation weight)."""
+from my_project.task import count_shard_examples
+
+
+def test_train_count_matches_fixture():
+    # batch_1 ships train.txt with 6308 image entries (verified fixture).
+    assert count_shard_examples(1, "train") == 6308
+
+
+def test_val_count_matches_fixture():
+    assert count_shard_examples(1, "val") == 1010
+
+
+def test_not_the_old_constant():
+    # Guard against regression to the hardcoded 10.
+    assert count_shard_examples(1, "train") != 10
+
+
+def test_counts_differ_across_splits():
+    assert count_shard_examples(1, "train") > count_shard_examples(1, "val")
+
+
+def test_missing_batch_returns_at_least_one():
+    # A non-existent shard must never yield 0 (would zero its FedAvg weight).
+    assert count_shard_examples(99999, "train") >= 1


### PR DESCRIPTION
## Problem
`client_app.fit()`/`evaluate()` reported a hardcoded `num_examples = 10`. FedAvg uses `num_examples` as the aggregation weight, so every client was weighted equally regardless of shard size. (Harmless under today's near-equal shards — ~6308 train each — but wrong the moment shards differ, e.g. real cross-silo deployments.)

## Fix
- `task.count_shard_examples(batch_id, split)` — counts non-empty lines in the split list file (`train.txt`/`val.txt`/`test.txt`), falls back to globbing `images/<split>/`, floors at 1 so no client ever gets a zero FedAvg weight.
- `fit` → `count_shard_examples(batch_id, "train")`; `evaluate` → `"val"`.
- Made `ultralytics` a lazy (annotation-only) import in `task.py` so the dataset/path helpers import without the heavy dep.

## Verification
`pytest tests/test_num_examples.py` → **5 passed** against the committed fixtures (train=6308, val=1010, ≠10, train>val, missing-shard ≥1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)