### PR TITLE
ci: add pytest workflow (CPU) for FL correctness tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: pytest (CPU)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: my-project
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install test dependencies (CPU-only torch)
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install numpy pyyaml pytest
+
+      - name: Run unit tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/my-project
+        run: pytest tests -q

--- a/my-project/pyproject.toml
+++ b/my-project/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "tqdm>=4.60.0"
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["."]
 

--- a/my-project/tests/conftest.py
+++ b/my-project/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest setup.
+
+Puts the project root (``my-project/``) on sys.path so ``my_project`` and
+``utils`` import whether or not the package was installed, and provides a stub
+for ``ultralytics`` (only referenced in type hints by the modules under test) so
+the fast unit tests don't require the heavy dependency.
+"""
+import os
+import sys
+import types
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+# Stub ultralytics if absent (real package is used when installed, e.g. full CI).
+if "ultralytics" not in sys.modules:
+    try:
+        import ultralytics  # noqa: F401
+    except Exception:
+        stub = types.ModuleType("ultralytics")
+        stub.YOLO = object
+        sys.modules["ultralytics"] = stub


### PR DESCRIPTION
Adds the missing test gate. Before this, the only workflow was the PR labeler — the FedAvg-correctness fixes (state_dict weights, real num_examples, portable paths) had no CI guard.

- **`.github/workflows/ci.yml`** — on push/PR, install CPU-only torch + numpy/pyyaml/pytest, run `pytest tests` on Python 3.10.
- **`tests/conftest.py`** — puts project root on `sys.path` and stubs `ultralytics` (only a type-hint dep for the modules under test) so the fast unit tests need no heavy install.
- **`pyproject.toml`** — `[project.optional-dependencies] dev = ["pytest"]`.

Verified locally: `pytest tests` → **13 passed**. This PR's own CI run is the cloud verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)