### PR TITLE
feat: persist aggregated global model each round (checkpointing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ Temporary Items
 
 # Runtime-generated data configs (materialize_data_yaml)
 **/data.runtime.yaml
+
+# Federated global-model checkpoints
+checkpoints/

--- a/my-project/my_project/server_app.py
+++ b/my-project/my_project/server_app.py
@@ -16,7 +16,7 @@ from flwr.server.client_manager import ClientManager
 # Ensure Ultralytics does not use HUB (prevents import issues)
 os.environ["ULTRALYTICS_HUB"] = "0"
 from ultralytics import YOLO
-from my_project.task import download_model, IS_WINDOWS, OS_NAME
+from my_project.task import download_model, should_checkpoint, IS_WINDOWS, OS_NAME
 from my_project.get_set_model import get_weights, set_weights
 
 from utils.logging_setup import configure_logging
@@ -63,6 +63,8 @@ class CustomBatchStrategy(FedAvg):
         batch_id_range: tuple = DEFAULT_BATCH_ID_RANGE,
         proximal_mu: float = 0.0,
         num_rounds: int = DEFAULT_NUM_ROUNDS,
+        checkpoint_dir: str = "checkpoints",
+        save_every: int = 1,
     ):
         super().__init__(
             fraction_fit=fraction_fit,
@@ -85,6 +87,14 @@ class CustomBatchStrategy(FedAvg):
         self.client_os_info: Dict[str, str] = {}  # Track client OS information
         self.num_rounds = num_rounds
         self.metrics_logger = MetricsLogger()  # writes logs/metrics.csv
+
+        # Global-model checkpointing: persist the aggregated model to disk so the
+        # federated result survives process exit. Lazily instantiate one YOLO to
+        # hold/save weights (created on first save to avoid a redundant load).
+        self.checkpoint_dir = checkpoint_dir
+        self.save_every = max(int(save_every), 1)
+        self._save_model = None
+        os.makedirs(self.checkpoint_dir, exist_ok=True)
         # proximal_mu > 0 turns on FedProx-style proximal regularization on clients.
         self.proximal_mu = float(proximal_mu)
         strategy_name = "FedProx" if self.proximal_mu > 0 else "FedAvg"
@@ -127,7 +137,30 @@ class CustomBatchStrategy(FedAvg):
         """Clear state that should be reset between rounds."""
         logger.debug(f"[Server] Clearing round state, resetting {len(self.used_batch_ids)} used batch IDs")
         self.used_batch_ids = set()
-    
+
+    def _save_global_model(self, weights, server_round: int) -> None:
+        """
+        Save the aggregated global weights as a self-contained YOLO checkpoint.
+
+        Loads the ndarray weights into a held YOLO model (via set_weights, which
+        now includes BatchNorm buffers) and writes both a per-round checkpoint and
+        a stable ``global_last.pt`` pointer. Failures are logged, never fatal —
+        a checkpointing error must not abort the federation.
+        """
+        try:
+            if self._save_model is None:
+                self._save_model = YOLO(MODEL_PATH)
+            if not set_weights(self._save_model.model, weights):
+                logger.error(f"[Server] Round {server_round}: set_weights failed; skipping checkpoint.")
+                return
+            round_path = os.path.join(self.checkpoint_dir, f"global_round_{server_round}.pt")
+            last_path = os.path.join(self.checkpoint_dir, "global_last.pt")
+            self._save_model.save(round_path)
+            self._save_model.save(last_path)
+            logger.info(f"[Server] Saved global checkpoint: {round_path} (and {last_path})")
+        except Exception as e:
+            logger.error(f"[Server] Failed to save global checkpoint at round {server_round}: {e}", exc_info=True)
+
     def configure_fit(
         self,
         server_round: int,
@@ -280,7 +313,12 @@ class CustomBatchStrategy(FedAvg):
             weights = parameters_to_ndarrays(parameters)
             weights_checksum = sum(w.sum() for w in weights if w.size > 0)
             logger.info(f"[Server] Aggregated parameters with checksum: {weights_checksum}")
-            
+
+            # Persist the aggregated global model on the configured cadence and on
+            # the final round, so the federated result is recoverable after exit.
+            if should_checkpoint(server_round, self.save_every, self.num_rounds):
+                self._save_global_model(weights, server_round)
+
             # Add checksum and OS counts to metrics for tracking
             metrics["weights_checksum"] = float(weights_checksum)
             metrics["server_os"] = OS_NAME
@@ -380,6 +418,8 @@ def server_fn(context: Context):
         proximal_mu = 0.1  # sensible default when FedProx is requested without a mu
     if strategy_name != "fedprox":
         proximal_mu = 0.0  # force plain FedAvg
+    checkpoint_dir = str(run_config.get("checkpoint_dir", "checkpoints"))
+    save_every = int(run_config.get("save_every", 1))
     logger.info(
         f"[Server] run_config -> num_rounds={num_rounds}, fraction_fit={fraction_fit}, "
         f"local_epochs={local_epochs}, min_clients={min_clients}, "
@@ -420,6 +460,8 @@ def server_fn(context: Context):
         batch_id_range=DEFAULT_BATCH_ID_RANGE,
         proximal_mu=proximal_mu,
         num_rounds=num_rounds,
+        checkpoint_dir=checkpoint_dir,
+        save_every=save_every,
     )
 
     # Configure server

--- a/my-project/my_project/task.py
+++ b/my-project/my_project/task.py
@@ -86,6 +86,19 @@ def get_data_yaml_path(batch_id):
     """
     return get_batch_path(batch_id) / "data.yaml"
 
+
+def should_checkpoint(server_round, save_every, num_rounds):
+    """
+    Whether to persist the global model after a given round.
+
+    True on the configured cadence (every ``save_every`` rounds) and always on
+    the final round, so the federated result is never lost. Pure/dependency-free
+    so it is unit-testable without the flwr/ultralytics runtime.
+    """
+    save_every = max(int(save_every), 1)
+    return (server_round % save_every == 0) or (server_round >= num_rounds)
+
+
 def count_shard_examples(batch_id, split="train"):
     """
     Count the number of examples in a client's data shard for a given split.

--- a/my-project/pyproject.toml
+++ b/my-project/pyproject.toml
@@ -35,6 +35,8 @@ local_epochs = 4
 min_clients = 3
 strategy = "fedavg"   # "fedavg" or "fedprox"
 proximal_mu = 0.0     # FedProx proximal strength; >0 enables FedProx (default 0.1 if strategy=fedprox)
+checkpoint_dir = "checkpoints"  # where the aggregated global model is saved
+save_every = 1                  # save a global checkpoint every N rounds (always on final round)
 
 
 [tool.flwr.federations]

--- a/my-project/tests/test_checkpoint.py
+++ b/my-project/tests/test_checkpoint.py
@@ -1,0 +1,22 @@
+"""Tests for the checkpoint cadence predicate (should_checkpoint)."""
+from my_project.task import should_checkpoint
+
+
+def test_saves_every_round_when_save_every_1():
+    assert all(should_checkpoint(r, 1, 3) for r in range(1, 4))
+
+
+def test_respects_save_every_cadence():
+    # save_every=2 over 5 rounds: rounds 2 and 4 by cadence, plus final round 5.
+    got = [r for r in range(1, 6) if should_checkpoint(r, 2, 5)]
+    assert got == [2, 4, 5]
+
+
+def test_always_saves_final_round_off_cadence():
+    # save_every=10 but only 3 rounds → never on cadence, still saves round 3.
+    assert should_checkpoint(3, 10, 3) is True
+    assert should_checkpoint(1, 10, 3) is False
+
+
+def test_save_every_zero_is_treated_as_one():
+    assert should_checkpoint(1, 0, 3) is True


### PR DESCRIPTION
## Problem
The server aggregated weights in memory but never saved them — the federated result was lost on exit, and there was no artifact to deploy.

## Fix
- `CustomBatchStrategy` saves the aggregated global model in `aggregate_fit` on a configurable cadence and always on the final round → `checkpoints/global_round_N.pt` + a stable `checkpoints/global_last.pt`. Save errors are logged, never fatal.
- Weights are loaded via `set_weights` (now buffer-complete, PR #21), so the checkpoint carries correct **BatchNorm statistics**.
- `task.should_checkpoint(round, save_every, num_rounds)` — pure, dependency-free cadence predicate (unit-tested without the flwr/ultralytics runtime).
- `run_config` keys `checkpoint_dir` + `save_every` wired through `server_fn`; documented in `pyproject.toml`; `checkpoints/` gitignored.

## Verification
- `pytest tests` → **17 passed** (incl. 4 cadence tests).
- Real YOLOv8 round-trip (`set_weights` → `YOLO.save` → reload) **preserved a perturbed BatchNorm `running_mean`** and the file reloads as a usable model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)