### PR TITLE
feat: rotating, bounded logging

### DIFF
--- a/my-project/tests/test_logging.py
+++ b/my-project/tests/test_logging.py
@@ -1,0 +1,32 @@
+"""Tests for rotating, bounded logging setup."""
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+from utils.logging_setup import configure_logging
+
+
+def test_file_handler_is_rotating(tmp_path):
+    log_file = tmp_path / "sub" / "test.log"
+    lg = configure_logging("fl_av_test_rotating", str(log_file))
+    handlers = [h for h in lg.handlers if isinstance(h, RotatingFileHandler)]
+    assert handlers, "expected a RotatingFileHandler"
+    assert handlers[0].maxBytes > 0
+    assert handlers[0].backupCount >= 1
+    # The handler created its parent directory.
+    assert log_file.parent.is_dir()
+    lg.info("hello")
+    assert log_file.exists()
+
+
+def test_no_duplicate_handlers_on_repeat_calls():
+    a = configure_logging("fl_av_test_dup", None)
+    n = len(a.handlers)
+    b = configure_logging("fl_av_test_dup", None)
+    assert a is b
+    assert len(b.handlers) == n  # not stacked on repeat configuration
+
+
+def test_does_not_propagate_to_root():
+    lg = configure_logging("fl_av_test_propagate", None)
+    assert lg.propagate is False

--- a/my-project/utils/logging_setup.py
+++ b/my-project/utils/logging_setup.py
@@ -1,31 +1,47 @@
 import logging
+import os
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
+
+# Rotation defaults (overridable via env for production tuning).
+_MAX_BYTES = int(os.environ.get("FL_AV_LOG_MAX_BYTES", 10 * 1024 * 1024))  # 10 MB
+_BACKUP_COUNT = int(os.environ.get("FL_AV_LOG_BACKUP_COUNT", 5))
+_LEVEL = os.environ.get("FL_AV_LOG_LEVEL", "INFO").upper()
+
 
 def configure_logging(logger_name, log_file=None):
     """
-    Configures logging for the given module with an optional log file.
-    
+    Configure a module logger with a rotating file handler (or console).
+
+    Production-friendly: log files rotate at FL_AV_LOG_MAX_BYTES (default 10 MB)
+    keeping FL_AV_LOG_BACKUP_COUNT backups (default 5), so logs can't grow
+    unbounded and fill the disk. Level is FL_AV_LOG_LEVEL (default INFO).
+
     Args:
         logger_name (str): The name of the logger.
-        log_file (str, optional): Path to the log file. Defaults to None (console logging).
-    
+        log_file (str, optional): Path to the log file. None -> console logging.
+
     Returns:
         logging.Logger: Configured logger instance.
     """
     logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(getattr(logging, _LEVEL, logging.INFO))
 
-    # Ensure log directory exists
-    Path("logs").mkdir(exist_ok=True)
-
-    # Create file handler if log_file is specified, otherwise use console logging
-    handler = logging.FileHandler(log_file) if log_file else logging.StreamHandler()
-    
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
+    if log_file:
+        # Ensure the log file's own directory exists (not a hardcoded "logs").
+        Path(os.path.dirname(log_file) or ".").mkdir(parents=True, exist_ok=True)
+        handler = RotatingFileHandler(
+            log_file, maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT
+        )
+    else:
+        handler = logging.StreamHandler()
     handler.setFormatter(formatter)
 
-    # Avoid duplicate handlers
-    if not logger.hasHandlers():
+    # Attach our handler only once per logger; don't double-log via the root.
+    if not logger.handlers:
         logger.addHandler(handler)
-    
+    logger.propagate = False
+
     return logger


### PR DESCRIPTION
## Problem
`configure_logging` used a plain `FileHandler` — logs grew unbounded (disk-fill risk in production) and it always created a hardcoded `logs/` dir.

## Fix
- `RotatingFileHandler`: rotate at `FL_AV_LOG_MAX_BYTES` (default 10 MB), keep `FL_AV_LOG_BACKUP_COUNT` backups (default 5); level via `FL_AV_LOG_LEVEL`.
- Create the log file's own parent dir (not a fixed `logs/`).
- Fix handler de-dup (guard on `logger.handlers`) + `propagate=False` to stop double-logging through root.

## Verification
`pytest tests/test_logging.py` → **3 passed** (rotating+bounded, no dup handlers, no propagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)