### PR TITLE
feat: distributed deployment artifacts (SuperLink/SuperNode, TLS, Docker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ Temporary Items
 
 # Federated global-model checkpoints
 checkpoints/
+
+# TLS certificates (secrets)
+certs/

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,107 @@
+# Production Deployment (Flower Deployment Engine)
+
+Moves FL_AV off the single-process simulation onto a real distributed topology:
+one **SuperLink** (coordinator) and N **SuperNodes** (data owners), communicating
+over gRPC with TLS. Each SuperNode trains YOLOv8 on its own shard and only model
+weights cross the network.
+
+> These are deployment **artifacts**; they have not been run end-to-end in CI
+> (no SuperLink host / certs / GPU there). Pin image tags and the
+> torch/torchvision/CUDA triad to your hardware before going live.
+
+## Topology
+
+```
+                       flwr run . remote-deployment
+                                  │ (Exec API :9093, TLS)
+                          ┌───────▼────────┐
+                          │   SuperLink     │  CPU
+                          │  :9091 Driver   │
+                          │  :9092 Fleet    │
+                          │  :9093 Exec     │
+                          └───────▲────────┘
+                  gRPC+TLS :9092  │  (root cert = ca.crt)
+            ┌─────────────────────┼─────────────────────┐
+        ┌───▼────┐            ┌───▼────┐            ┌───▼────┐
+        │SuperNode│ GPU       │SuperNode│ GPU       │SuperNode│ GPU
+        │ part 0  │           │ part 1  │           │ part 2  │
+        │ batch_1 │           │ batch_2 │           │ batch_3 │
+        └─────────┘           └─────────┘           └─────────┘
+```
+
+## 1. Certificates (TLS)
+
+```bash
+cd my-project
+bash scripts/gen_certs.sh <superlink-host>   # DNS/IP clients will dial
+```
+
+Writes `certs/` (gitignored): `ca.crt`, `server.pem`, `server.key`. The server
+cert **SAN must match the address** clients dial or the TLS handshake fails. In
+production use a real CA and rotate certs (a rotation requires a SuperLink
+restart). Treat keys as secrets (Docker/K8s secrets), never commit them.
+
+## 2. Federation config
+
+`pyproject.toml` defines:
+
+```toml
+[tool.flwr.federations.remote-deployment]
+address = "127.0.0.1:9093"            # SuperLink Exec API
+root-certificates = "certs/ca.crt"
+```
+
+Point `address` at your SuperLink's Exec API host:port.
+
+## 3. Bring up the cluster
+
+```bash
+cd my-project
+docker compose up --build          # 1 SuperLink + 3 GPU SuperNodes (TLS)
+```
+
+- SuperNode image is CUDA-based; GPU passthrough needs the **NVIDIA Container
+  Toolkit** on the host. It asserts `torch.cuda.is_available()` at startup and
+  exits loudly if the GPU isn't visible.
+- Each SuperNode mounts **only its own** `batch/batch_N` shard (data locality)
+  and reads `FL_AV_DATA_ROOT=/data`.
+
+Manual (no Docker) equivalent:
+
+```bash
+# SuperLink
+flower-superlink --ssl-ca-certfile certs/ca.crt \
+  --ssl-certfile certs/server.pem --ssl-keyfile certs/server.key
+# Each SuperNode (own host/GPU)
+flower-supernode --superlink <host>:9092 --root-certificates certs/ca.crt \
+  --node-config "partition-id=0 num-partitions=3"
+```
+
+## 4. Run the federation
+
+```bash
+cd my-project
+flwr run . remote-deployment
+# override hyperparameters:
+flwr run . remote-deployment --run-config "num_server_rounds=5 strategy='fedprox' proximal_mu=0.1"
+```
+
+The aggregated global model is written to `checkpoints/global_round_N.pt` and
+`checkpoints/global_last.pt` on the SuperLink side (see [ARCHITECTURE.md](ARCHITECTURE.md)).
+
+## Ports
+
+| Port | API | Who connects |
+|------|-----|--------------|
+| 9091 | Driver / ServerApp | internal |
+| 9092 | Fleet | SuperNodes |
+| 9093 | Exec | `flwr run` |
+
+## Production checklist
+
+- [ ] Real CA-issued certs; SAN matches the dialed host; rotation plan.
+- [ ] Pin `flwr/superlink` tag and torch/torchvision/CUDA to your driver.
+- [ ] `FL_AV_DATA_ROOT` points at each node's mounted shard.
+- [ ] Resource limits / GPU reservations per SuperNode.
+- [ ] Ship `checkpoints/` to a model registry / object store (see Phase D).
+- [ ] Secrets via Docker/K8s secrets, not images or `pyproject.toml`.

--- a/my-project/docker-compose.yml
+++ b/my-project/docker-compose.yml
@@ -1,0 +1,71 @@
+# Local distributed FL bring-up: 1 SuperLink + 3 GPU SuperNodes over TLS.
+# Requires the NVIDIA Container Toolkit for GPU passthrough.
+#
+#   bash scripts/gen_certs.sh <superlink-host>   # once, writes certs/
+#   docker compose up --build                    # starts SuperLink + SuperNodes
+#   flwr run . remote-deployment                 # push the app (from the host)
+#
+# Each SuperNode mounts only its own data shard to enforce data locality.
+
+services:
+  superlink:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.superlink
+    ports:
+      - "9091:9091"
+      - "9092:9092"
+      - "9093:9093"
+    volumes:
+      - ./certs:/app/certs:ro
+    healthcheck:
+      test: ["CMD-SHELL", "true"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  supernode-0: &supernode
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.supernode
+    depends_on: [superlink]
+    environment:
+      FL_SUPERLINK_HOST: superlink
+      FL_SUPERLINK_FLEET_PORT: "9092"
+      FL_PARTITION_ID: "0"
+      FL_NUM_PARTITIONS: "3"
+      FL_AV_DATA_ROOT: /data
+    volumes:
+      - ./certs:/app/certs:ro
+      - ./batch/batch_1:/data/batch/batch_1:ro   # this node's shard only
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+  supernode-1:
+    <<: *supernode
+    environment:
+      FL_SUPERLINK_HOST: superlink
+      FL_SUPERLINK_FLEET_PORT: "9092"
+      FL_PARTITION_ID: "1"
+      FL_NUM_PARTITIONS: "3"
+      FL_AV_DATA_ROOT: /data
+    volumes:
+      - ./certs:/app/certs:ro
+      - ./batch/batch_2:/data/batch/batch_2:ro
+
+  supernode-2:
+    <<: *supernode
+    environment:
+      FL_SUPERLINK_HOST: superlink
+      FL_SUPERLINK_FLEET_PORT: "9092"
+      FL_PARTITION_ID: "2"
+      FL_NUM_PARTITIONS: "3"
+      FL_AV_DATA_ROOT: /data
+    volumes:
+      - ./certs:/app/certs:ro
+      - ./batch/batch_3:/data/batch/batch_3:ro

--- a/my-project/docker/.dockerignore
+++ b/my-project/docker/.dockerignore
@@ -1,0 +1,13 @@
+# Keep build context small — data, weights, logs, caches stay out of the image.
+batch/
+batch34/
+../full_data_run/
+logs/
+checkpoints/
+certs/
+**/__pycache__/
+**/*.pyc
+**/data.runtime.yaml
+*.pt
+.venv/
+.git/

--- a/my-project/docker/Dockerfile.superlink
+++ b/my-project/docker/Dockerfile.superlink
@@ -1,0 +1,12 @@
+# SuperLink (coordinator) image. CPU is sufficient — it aggregates, it doesn't train.
+# Pin to the same Flower version as pyproject (see docs/ENGINEERING_NOTES.md).
+FROM flwr/superlink:1.31.0
+
+# TLS certs are mounted at runtime (see docker-compose.yml), not baked in.
+# Exposed APIs: 9091 (Driver/ServerApp), 9092 (Fleet/SuperNodes), 9093 (Exec/flwr run).
+EXPOSE 9091 9092 9093
+
+ENTRYPOINT ["flower-superlink"]
+CMD ["--ssl-ca-certfile", "/app/certs/ca.crt", \
+     "--ssl-certfile", "/app/certs/server.pem", \
+     "--ssl-keyfile", "/app/certs/server.key"]

--- a/my-project/docker/Dockerfile.supernode
+++ b/my-project/docker/Dockerfile.supernode
@@ -1,0 +1,32 @@
+# SuperNode (data owner / trainer) image. GPU-capable: trains YOLOv8 locally.
+# Base on CUDA runtime so torch can use the GPU; install the project so
+# ultralytics + the FL client app are available.
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3.10 python3-pip git libgl1 libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+# CUDA-enabled torch, then the project (flwr supernode + ultralytics).
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+    python3 -m pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cu124 && \
+    python3 -m pip install --no-cache-dir -e .
+
+# Fail fast/loud if CUDA isn't actually visible inside the container.
+RUN python3 -c "import torch; print('CUDA available at build:', torch.cuda.is_available())"
+
+# SuperLink host/port and partition come from the environment at run time.
+ENV FL_SUPERLINK_HOST=superlink FL_SUPERLINK_FLEET_PORT=9092 \
+    FL_PARTITION_ID=0 FL_NUM_PARTITIONS=3
+
+ENTRYPOINT ["bash", "-lc", "\
+  python3 -c 'import torch; assert torch.cuda.is_available(), \"No GPU visible — check NVIDIA Container Toolkit\"' && \
+  flower-supernode \
+    --superlink ${FL_SUPERLINK_HOST}:${FL_SUPERLINK_FLEET_PORT} \
+    --root-certificates /app/certs/ca.crt \
+    --node-config \"partition-id=${FL_PARTITION_ID} num-partitions=${FL_NUM_PARTITIONS}\" \
+"]

--- a/my-project/pyproject.toml
+++ b/my-project/pyproject.toml
@@ -52,3 +52,11 @@ options.backend.client-resources.num-cpus = 2
 options.backend.client-resources.num-gpus = 0
 options.backend.init_args.num_cpus = 2
 options.backend.init_args.num_gpus = 0
+
+# Real distributed deployment (Flower Deployment Engine): one SuperLink + N
+# SuperNodes over gRPC+TLS. Point `address` at the SuperLink Exec API (9093) and
+# `root-certificates` at the CA cert. Run with: flwr run . remote-deployment
+# Override the host with the FL_SUPERLINK_HOST env at launch time if templating.
+[tool.flwr.federations.remote-deployment]
+address = "127.0.0.1:9093"
+root-certificates = "certs/ca.crt"

--- a/my-project/scripts/gen_certs.sh
+++ b/my-project/scripts/gen_certs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Generate self-signed TLS certificates for a Flower SuperLink <-> SuperNode
+# deployment. For development / internal use; in production use a real CA.
+#
+# Produces, under certs/ (gitignored):
+#   ca.crt / ca.key        - certificate authority
+#   server.pem / server.key- SuperLink server cert (SAN must match the dialed host)
+#
+# Usage:
+#   bash scripts/gen_certs.sh [SUPERLINK_HOST]
+# SUPERLINK_HOST defaults to "localhost"; pass the DNS name or IP clients dial.
+set -euo pipefail
+
+HOST="${1:-localhost}"
+CERT_DIR="${CERT_DIR:-certs}"
+DAYS="${DAYS:-365}"
+
+mkdir -p "$CERT_DIR"
+cd "$CERT_DIR"
+
+echo "[certs] Generating CA..."
+openssl genrsa -out ca.key 4096
+openssl req -x509 -new -nodes -key ca.key -sha256 -days "$DAYS" \
+  -subj "/O=FL_AV/CN=FL_AV-CA" -out ca.crt
+
+echo "[certs] Generating SuperLink server cert for host: $HOST (SAN must match dialed address)"
+openssl genrsa -out server.key 4096
+openssl req -new -key server.key -subj "/O=FL_AV/CN=$HOST" -out server.csr
+
+cat > server.ext <<EOF
+subjectAltName = DNS:$HOST, DNS:localhost, IP:127.0.0.1
+EOF
+
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -days "$DAYS" -sha256 -extfile server.ext -out server.pem
+
+rm -f server.csr server.ext ca.srl
+echo "[certs] Done. Files in $CERT_DIR/: ca.crt ca.key server.pem server.key"
+echo "[certs] SuperLink:  --ssl-ca-certfile $CERT_DIR/ca.crt --ssl-certfile $CERT_DIR/server.pem --ssl-keyfile $CERT_DIR/server.key"
+echo "[certs] SuperNodes: --root-certificates $CERT_DIR/ca.crt   (and set the federation root-certificates in pyproject.toml)"


### PR DESCRIPTION
Moves FL_AV toward the **Flower Deployment Engine** (real SuperLink + N GPU SuperNodes over gRPC+TLS) instead of single-process simulation.

> **Artifacts only** — not runtime-verified in this environment (no SuperLink host, TLS certs, or GPU). Pin image tags and the torch/torchvision/CUDA triad to target hardware before production. See `docs/DEPLOYMENT.md` checklist.

- `pyproject.toml` → `[tool.flwr.federations.remote-deployment]` (`address` + `root-certificates`); run with `flwr run . remote-deployment`.
- `scripts/gen_certs.sh` → dev CA + SuperLink server cert (SAN-aware; secrets gitignored).
- `docker/Dockerfile.superlink` (`flwr/superlink:1.31.0`), `Dockerfile.supernode` (CUDA base, torch+ultralytics, asserts `torch.cuda.is_available()`), `.dockerignore`.
- `docker-compose.yml` → 1 SuperLink + 3 GPU SuperNodes, per-node shard mounts (data locality), NVIDIA device reservations.
- `docs/DEPLOYMENT.md` → topology diagram, cert/bring-up/run steps, ports, prod checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)