### PR TITLE
build: upgrade Flower 1.13.1 -> 1.31.0 (drop unused flwr-datasets)

### DIFF
--- a/my-project/pyproject.toml
+++ b/my-project/pyproject.toml
@@ -8,12 +8,17 @@ version = "1.0.0"
 description = "Federated Learning with YOLOv5 using Flower"
 license = "Apache-2.0"
 dependencies = [
-    "flwr[simulation]==1.13.1",
-    "flwr-datasets[vision]==0.3.0",
-    "ultralytics",
-    "numpy>=1.21.0",
+    # Flower upgraded 1.13.1 -> 1.31.0 (latest). The legacy ServerApp(server_fn=...)
+    # + Strategy(configure_fit/aggregate_fit) API the project uses still imports and
+    # constructs under 1.31 (verified). See docs/ENGINEERING_NOTES.md.
+    "flwr[simulation]>=1.31.0,<2.0.0",
+    # flwr-datasets dropped: it was unused in source and pinned an old version that
+    # blocked the flwr upgrade. The project partitions its own BDD100K batch shards.
+    "ultralytics>=8.0.0",
+    "numpy>=1.26.0",
     "scipy>=1.7.0",
     "pandas>=1.3.0",
+    "pyyaml>=6.0",
     "tqdm>=4.60.0"
 ]
 


### PR DESCRIPTION
## Why
Project pinned `flwr==1.13.1` — **18 minor releases behind** the latest `1.31.0`.

## What
- `flwr[simulation] >=1.31.0,<2.0.0`. The legacy `ServerApp(server_fn=...)` + `Strategy(configure_fit/aggregate_fit)` API the project uses **still imports and constructs under 1.31** (verified), so this bump needs no rewrite to the new Message/`ArrayRecord` API.
- **Dropped `flwr-datasets[vision]==0.3.0`** — unused in source, and it pinned an old version that constrained the upgrade. The project partitions its own BDD100K batch shards.
- Declared `pyyaml` (used by `task.py`), bumped numpy floor to `>=1.26`, pinned `ultralytics>=8`.

## Verification (CPU venv, flwr 1.31.0)
- `my_project.server_app` / `my_project.client_app` import and construct their `ServerApp`/`ClientApp` — no Flower deprecation warnings at import.
- `pytest tests` → **17 passed**.

> Full distributed/simulation runtime not exercised here (needs ray + GPU + data). A future migration to the new `@app.main()` / `strategy.start()` Message API is noted in `docs/ENGINEERING_NOTES.md` — not required for this upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)