### PR TITLE
feat: data/model hygiene scaffolding (DVC, env config, runbook)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ checkpoints/
 
 # TLS certificates (secrets)
 certs/
+
+# Local secrets
+.env

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -1,0 +1,63 @@
+# Data & Model Management
+
+Why and how FL_AV handles its dataset shards and model weights — and how to stop
+shipping ~400 MB of binaries inside the git repo.
+
+## The problem
+
+| Tracked in git | Size | Issue |
+|----------------|------|-------|
+| `batch/` (10 BDD100K shards) | ~326 MB | images/labels in version control bloat every clone |
+| `models/*.pt`, `yolov8n.pt`, `models/dump_models/*.pt`, `logs/yolov8s.pt` | ~75 MB | binary weights + duplicates, no versioning |
+
+Git stores every version of these forever — clones are slow, diffs are useless,
+and there's no model lineage.
+
+## The approach: DVC pointers + object storage
+
+[DVC](https://dvc.org) replaces large files with tiny `*.dvc` pointer files
+(committed to git) and stores the actual bytes in an S3-compatible remote.
+
+**Crucially, the split-list files (`train.txt`/`val.txt`/`test.txt`) stay tracked
+in git** — they're tiny, and the unit tests use them as fixtures
+(`count_shard_examples`). Only `images/` + `labels/` dirs and `.pt` weights go to
+DVC. `scripts/setup_dvc.sh` is written to preserve this split.
+
+```bash
+cd my-project
+pip install "dvc[s3]"
+export DVC_REMOTE_URL=s3://your-bucket/fl_av     # or set in .env
+bash scripts/setup_dvc.sh
+git add -A '*.dvc' .gitignore .dvc && git commit -m "chore: track data/weights with DVC"
+dvc push                                          # upload blobs
+
+# fresh clone / CI / a new SuperNode:
+dvc pull
+```
+
+> **History note:** this is **non-destructive** — it stops tracking the blobs
+> going forward but they remain in git *history*, so existing clones don't shrink.
+> Reclaiming that space needs a one-time `git filter-repo` purge + force-push
+> (destructive; all clones must re-clone). That step is intentionally **not**
+> automated and is gated on an explicit decision — see
+> [ENGINEERING_NOTES.md](ENGINEERING_NOTES.md) §7.
+
+## Trained global models
+
+Federated checkpoints land in `checkpoints/` (`global_round_N.pt`,
+`global_last.pt`) — gitignored. Publish the ones you keep to a model
+registry / object-store prefix rather than committing them; treat
+`global_last.pt` as the deployable artifact.
+
+## Duplicate weights to retire
+
+`models/dump_models/` and `logs/yolov8s.pt` duplicate `models/yolov8s.pt`. Per the
+archive-don't-delete policy, move them under `archive/` (or DVC-track then
+git-untrack) rather than deleting. They are not referenced by the FL code
+(`MODEL_PATH = "models/yolov8s.pt"`).
+
+## Secrets / config
+
+Runtime config and credentials come from the environment, never from
+`pyproject.toml` or images. Copy `.env.example` → `.env` (gitignored):
+`FL_AV_DATA_ROOT`, log tuning, SuperLink host, and DVC/S3 credentials.

--- a/my-project/.dvcignore
+++ b/my-project/.dvcignore
@@ -1,0 +1,4 @@
+# Patterns DVC should ignore when hashing tracked directories.
+**/data.runtime.yaml
+**/*.cache
+**/__pycache__/

--- a/my-project/.env.example
+++ b/my-project/.env.example
@@ -1,0 +1,21 @@
+# Copy to .env (gitignored) and fill in. Loaded by your shell/orchestrator, not
+# committed. No secrets belong in pyproject.toml or container images.
+
+# --- Data ---
+# Root that contains the batch/ shards. In containers, point at the mounted volume.
+FL_AV_DATA_ROOT=/data
+
+# --- Logging (utils/logging_setup.py) ---
+FL_AV_LOG_LEVEL=INFO
+FL_AV_LOG_MAX_BYTES=10485760     # 10 MB per file before rotation
+FL_AV_LOG_BACKUP_COUNT=5
+
+# --- Deployment (Flower Deployment Engine) ---
+FL_SUPERLINK_HOST=superlink
+FL_SUPERLINK_FLEET_PORT=9092
+
+# --- DVC remote (scripts/setup_dvc.sh) ---
+DVC_REMOTE_URL=s3://CHANGE-ME-bucket/fl_av
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_ENDPOINT_URL=                # set for S3-compatible stores (MinIO, R2, etc.)

--- a/my-project/scripts/setup_dvc.sh
+++ b/my-project/scripts/setup_dvc.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# One-time DVC setup to move large data/weights out of git tracking while keeping
+# the tiny split-list fixtures (train.txt/val.txt/test.txt) that the unit tests
+# rely on. NON-destructive to git history (no force-push); it only stops tracking
+# the blobs going forward and creates .dvc pointers.
+#
+# Prereqs: pip install "dvc[s3]"   and an S3-compatible bucket.
+# Usage:   bash scripts/setup_dvc.sh
+# Then:    git add *.dvc .gitignore && git commit && dvc push
+set -euo pipefail
+
+cd "$(dirname "$0")/.."   # my-project/
+
+command -v dvc >/dev/null || { echo "dvc not installed: pip install 'dvc[s3]'"; exit 1; }
+[ -d .dvc ] || dvc init --subdir
+
+# Large model weights -> DVC (pointers committed, blobs pushed to remote).
+for f in models/yolov8s.pt yolov8n.pt models/dump_models/*.pt logs/yolov8s.pt; do
+  [ -f "$f" ] && dvc add "$f"
+done
+
+# Per-shard images + labels -> DVC. We intentionally DO NOT dvc-add the whole
+# batch dir so train.txt/val.txt/test.txt stay in git (test fixtures + cheap).
+for d in batch/batch_*/images batch/batch_*/labels batch34/batch_*/images batch34/batch_*/labels; do
+  [ -d "$d" ] && dvc add "$d"
+done
+
+# Remote (S3-compatible). Override via env before running.
+REMOTE_URL="${DVC_REMOTE_URL:-s3://CHANGE-ME-bucket/fl_av}"
+dvc remote add -d --force storage "$REMOTE_URL"
+[ -n "${AWS_ENDPOINT_URL:-}" ] && dvc remote modify storage endpointurl "$AWS_ENDPOINT_URL"
+
+echo
+echo "Next:"
+echo "  git add -A '*.dvc' .gitignore .dvc && git commit -m 'chore: track data/weights with DVC'"
+echo "  dvc push          # upload blobs to $REMOTE_URL"
+echo "On a fresh clone:   dvc pull"


### PR DESCRIPTION
~400 MB of dataset shards + `.pt` weights are committed to git. This adds the **non-destructive** path to move them to object storage and externalize config — without breaking test fixtures or rewriting history.

- **`scripts/setup_dvc.sh`** — selective DVC setup: tracks `images/`+`labels/` dirs and `.pt` weights, but **keeps `train/val/test.txt` in git** (the unit-test fixtures). Configures an S3-compatible remote from env.
- **`.dvcignore`**, **`.env.example`** (`FL_AV_DATA_ROOT`, log tuning, SuperLink host, DVC/S3 creds; `.env` gitignored).
- **`docs/DATA.md`** — problem table, DVC workflow, `dvc pull` on fresh clone/CI, trained-model handling, duplicate-weights retirement, secrets policy.

> Per your call: **DVC + gitignore only, no history rewrite.** The destructive `git filter-repo` purge is documented but intentionally not automated (ENGINEERING_NOTES §7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)