### PR TITLE
feat(dashboard): draw the labels, and serve the pictures the trainer already made

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Open the one file that owns the thing. Do not read the package to find it.
 | Dashboard markup, a new panel, an element id | `pipeline/static/index.html` |
 | Chart axes, ticks, tooltips, sparkline | `pipeline/static/js/chart.js` |
 | The fleet grid / vehicle drawer / live polling / run form | `pipeline/static/js/{fleet,drawer,live,control}.js` |
+| Label boxes drawn over a frame, the trainer's own pictures | `pipeline/static/js/consumed.js` |
+| Which of ultralytics' output pictures are served, and their captions | `pipeline/train_artifacts.py` — `KINDS` |
 | An HTTP route or what `/api/state` returns | `pipeline/server.py` |
 | Which stages exist, what "already done" means, gating | `pipeline/stages.py` |
 | How a stage subprocess is run, env, SuperLink handling | `pipeline/runner.py` |
@@ -166,7 +168,7 @@ branch dies.
 
 ```bash
 python -m pytest my-project/tests -q     # 31 tests
-python -m pytest pipeline/tests -q       # 59 tests
+python -m pytest pipeline/tests -q       # 121 tests
 python -m pipeline.verify                # the four pass criteria against the last run
 python -m pipeline.holdout --evaluate    # the global model on data no vehicle saw
 ```

--- a/docs/OSS_TOOLING_REVIEW.md
+++ b/docs/OSS_TOOLING_REVIEW.md
@@ -1,0 +1,44 @@
+# Open-source tooling: what to add, what to refuse
+
+Reviewed 2026-08-16. The question was "what open-source projects should this one
+assemble from?", and the honest answer for most of them is *none, because the thing
+they provide is already on disk here*. That is rule 4 — assemble before building — read
+in both directions: use what exists, and do not adopt a service to do what a file does.
+
+Each row below is judged against three constraints this repo does not bend:
+
+1. **Data is never committed** and never leaves the machine. That kills every hosted
+   tracker regardless of quality.
+2. **No credentials.** Nothing here needs any; nothing here may start needing any.
+3. **`pipeline/` invokes `my-project/`, it does not modify it.** A tool that requires
+   instrumentation inside the training loop costs a gated branch, not an afternoon.
+
+## Verdicts
+
+| Tool | What it would give | Verdict |
+|---|---|---|
+| **ultralytics' own output** | batch mosaics, label distributions, truth-vs-prediction, confusion matrix, PR/F1 curves — 14 files per vehicle per round | **wired.** They were already being written and never served. See `pipeline/train_artifacts.py` |
+| **MLflow** | metrics store, run history, comparison | **already chosen, still broken.** It refused the last run: *"the filesystem tracking backend is in maintenance mode"*. Needs a SQLite backing store. Backlog 80 — fixing it is smaller than any panel that would duplicate it |
+| **Ray Dashboard** | actor scheduling, GPU internals | **already assembled.** Linked from the header |
+| **FiftyOne** (voxel51) | dataset curation app, embedding-based near-duplicate and label-error search, YOLO-format import | **deferred, not refused.** Its unique capability is embeddings, which is a phase-4 data-quality question. Its cost is a MongoDB process, a second port and a large install — too much to pay for *looking at pictures*, which is now free. Revisit for backlog 44 (data-quality audit) and 65 (leakage), where nothing else can do the job |
+| **`supervision`** (Roboflow) | server-side box/mask drawing, YOLO↔COCO↔VOC conversion | **refused for the overlay.** YOLO labels are already normalised, so an SVG over the `<img>` draws them with no dependency and lets the browser toggle them without a refetch. Reconsider only if a *rendered* artifact is ever needed outside the browser |
+| **Rerun** | live multimodal streaming viewer, excellent for watching a pipeline run | **refused for now.** Would require logging from `client_app.py` — the ⚠ zone — and the data here is per-round, not per-frame time series. Genuinely the right answer if per-step training telemetry is ever wanted |
+| **DVC** | dataset versioning | **refused.** Already argued in `docs/PHASED_PLAN.md` phase 4: it adds a remote, a cache and a daemon to a repo whose hard rule is that data is never committed. The content-hash manifest is the part that was actually needed |
+| **W&B / Comet / Neptune** | hosted experiment tracking | **refused on the credentials rule**, not on quality |
+| **Label Studio / CVAT** | annotation | **not needed.** BDD100K arrives labelled; this project does not annotate |
+| **Streamlit / Gradio** | a UI without writing one | **refused.** The dashboard exists, has no build step and serves off disk. Adding a framework now would be a rewrite disguised as an integration |
+| **Opacus / Flower's DP mods** | differential privacy with a stated ε | **phase 5, item 8.** The honest privacy story, and the only one that makes "federated" mean more than "not pooled" |
+| **Docker / uv lockfile** | reproducible environment | **accepted, separate branch.** See the production-readiness plan |
+
+## The one rule this review kept running into
+
+Every candidate that lost, lost the same way: it would have produced something the repo
+already had, and charged a daemon for it. The winner was not a project at all — it was
+noticing that the trainer had been drawing the pictures all along.
+
+## Sources
+
+- [voxel51/fiftyone](https://github.com/voxel51/fiftyone) — dataset curation, MongoDB backend
+- [FiftyOne integrations](https://docs.voxel51.com/integrations/index.html)
+- [rerun-io/rerun](https://github.com/rerun-io/rerun), [rerun-sdk on PyPI](https://pypi.org/project/rerun-sdk/) — 0.34.1, July 2026
+- [supervision — annotators](https://supervision.roboflow.com/annotators/), [datasets](https://supervision.roboflow.com/datasets/)

--- a/docs/prompts/2026-08-16-data-consumption-view.md
+++ b/docs/prompts/2026-08-16-data-consumption-view.md
@@ -1,0 +1,68 @@
+# Prompt — show what YOLO consumes, not only how much of it
+
+**Branch:** `feat/data-consumption-view` · **Written:** 2026-08-16
+
+> Honesty note: this was written after the code, not before it. The session began from
+> a broad request ("make the data and how the model uses it visible, more UI, more live
+> feed") and the shape of the increment was only decided once the repo had been read.
+> `docs/prompts/README.md` is right that a reconstructed prompt records what happened
+> rather than what was intended; this one is kept because the *rejected* options below
+> are the part worth keeping, and they were genuinely weighed before any file changed.
+
+## The brief
+
+The Data tab answers *how much*: images per shard, class histograms, weather mix,
+label density, holdout leakage. It cannot answer *is the model looking at what we think
+it is looking at* — the question that every silent failure in this project's history
+turned out to hinge on. Nothing in the dashboard has ever drawn a label.
+
+Make the data path visible:
+
+1. Draw each shard frame's label file over the frame.
+2. Surface what the trainer itself saw and predicted, per vehicle.
+3. Do not add a service, a daemon, a port, or a dependency to do it.
+
+## What was found first, and what it changed
+
+Ultralytics already writes, per vehicle, per round, into its run directory:
+`train_batch{0,1,2}.jpg` (real batches after mosaic and augmentation, boxes drawn),
+`labels.jpg`, `val_batch{n}_labels.jpg` beside `val_batch{n}_pred.jpg`,
+`confusion_matrix_normalized.png`, the PR/F1 curves, `results.png`. Fourteen files per
+vehicle, on disk since the last run, never once looked at.
+
+That inverted the task: the work is not *producing* these pictures, it is *serving*
+them. Rule 4 — assemble before building.
+
+## Rejected
+
+| Option | Why not |
+|---|---|
+| **FiftyOne** | The right tool for the job it does, and it costs a MongoDB process, a second web app on a second port, and a ~400 MB install to show pictures this repo already has on disk. Its real capability — embedding-based near-duplicate and label-error search — is a phase-4 question, not a UI one. Kept as a candidate in `docs/OSS_TOOLING_REVIEW.md`, not wired here. |
+| **`supervision`** | Would draw the boxes server-side. But then the frame goes over the wire twice, a rendering dependency enters the project, and the browser can no longer toggle the overlay without a refetch. The label format is already normalised; an SVG over the `<img>` needs no library at all. |
+| **Rerun** | Live streaming visualisation, genuinely good, and it would mean logging from `client_app.py` — the ⚠ zone — for a view of data that is not time-series. |
+| **A second dashboard page** | The Data tab is where the reader already is. |
+
+## Built
+
+| | |
+|---|---|
+| `pipeline/train_artifacts.py` | locates each vehicle's ultralytics run directory by **glob**, not by construction (the path depends on that machine's ultralytics `runs_dir` setting), and allowlists which filenames may be served |
+| `dataset_stats.boxes()` | one frame's label rows, normalised, malformed rows skipped rather than raised on |
+| 3 routes | `/api/shard-labels/<vid>/<name>`, `/api/train-artifacts`, `/api/train-artifact/<vid>/<name>` |
+| `static/js/consumed.js` | the unit-square SVG overlay, and the gallery of the trainer's pictures grouped as *batches as fed* / *truth vs prediction* / *where it fails* |
+
+## Verification
+
+- `pytest pipeline/tests -q` → 121 passed.
+- Three new tests: the allowlist refuses `weights/best.pt`, `args.yaml` and `../../../CLAUDE.md`;
+  a label file with two broken rows still yields its two good ones; and the overlay
+  geometry is executed under node against a fake DOM.
+- The geometry test was mutated (`b.w / 2` → `b.w / 3`) and **failed**, then restored
+  and passed — a check that cannot fail is not a check.
+- Live against a running server: `labels.jpg` 200 image/jpeg 129 949 B,
+  `confusion_matrix_normalized.png` 200 image/png 289 765 B, `weights/best.pt` 404,
+  traversal 404. `/api/shard-labels/1/00091078-7cff8ea6.jpg` → 23 boxes, 0 outside `[0,1]`.
+- **Not verified: the rendered page.** Both browser automation paths were unavailable
+  in this session (extension not connected; the devtools profile was already in use).
+  The geometry, the routes and the empty states are covered by the tests above; the
+  visual result is not. Say so rather than imply otherwise.

--- a/pipeline/dataset_stats.py
+++ b/pipeline/dataset_stats.py
@@ -61,6 +61,32 @@ def class_histogram(label_dir: Path) -> dict[str, int]:
     return counts
 
 
+def boxes(vid: int, image_name: str) -> list[dict]:
+    """The label rows for one shard image, as the trainer reads them.
+
+    YOLO label format is `cls cx cy w h`, already normalised to the image, which is
+    why nothing here needs the image's pixel size: the browser draws these straight
+    into a unit-square overlay. Malformed rows are skipped rather than raised on — a
+    label file with a bad row still has good rows, and the point of drawing these is
+    to *see* that something is wrong.
+    """
+    stem = Path(image_name).stem
+    path = paths.VEHICLE_BATCHES / f"batch_{int(vid)}" / "labels" / "train" / f"{stem}.txt"
+    if not path.is_file():
+        return []
+    out = []
+    for row in path.read_text(errors="replace").splitlines():
+        parts = row.split()
+        if len(parts) < 5:
+            continue
+        try:
+            cls, cx, cy, w, h = int(float(parts[0])), *map(float, parts[1:5])
+        except ValueError:
+            continue
+        out.append({"cls": cls, "cx": cx, "cy": cy, "w": w, "h": h})
+    return out
+
+
 def _mix(names: list[str], index: dict) -> dict[str, dict[str, int]]:
     out = {"weather": {}, "scene": {}, "timeofday": {}}
     for name in names:

--- a/pipeline/server.py
+++ b/pipeline/server.py
@@ -19,7 +19,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from . import (baseline, dataset_stats, docs_index, gpu, holdout, ledger, logparse, paths,
-               plan, stages, vehicle_metrics, vehicles, verify)
+               plan, stages, train_artifacts, vehicle_metrics, vehicles, verify)
 from .runner import Run
 from .stages import Config
 
@@ -236,6 +236,12 @@ class Handler(BaseHTTPRequestHandler):
             return self._json(plan.plan(CONFIG))
         if self.path.startswith("/api/vehicle/"):
             return self._vehicle()
+        if self.path.split("?")[0] == "/api/train-artifacts":
+            return self._json(train_artifacts.listing())
+        if self.path.startswith("/api/train-artifact/"):
+            return self._train_artifact()
+        if self.path.startswith("/api/shard-labels/"):
+            return self._shard_labels()
         if self.path.startswith("/api/shard-image/"):
             return self._shard_image()
         if self.path.startswith("/reports/"):
@@ -278,6 +284,37 @@ class Handler(BaseHTTPRequestHandler):
             return self._json({"error": "vehicle id must be an integer"}, 400)
         root = paths.VEHICLE_BATCHES / f"batch_{int(vid)}" / "images" / "train"
         target = safe_child(root, name)
+        if target is None:
+            return self._json({"error": "not found"}, 404)
+        ctype = "image/png" if target.suffix.lower() == ".png" else "image/jpeg"
+        self._send(200, target.read_bytes(), ctype)
+
+    def _shard_labels(self) -> None:
+        """The label rows for one shard image, so the browser can draw them on it.
+
+        Sent as normalised numbers rather than as a rendered image: the overlay is an
+        SVG over the same `<img>`, so there is no second copy of the frame on the wire
+        and no server-side image library in the dependency list.
+        """
+        rel = self.path[len("/api/shard-labels/"):].split("?")[0]
+        vid, _, name = rel.partition("/")
+        if not vid.isdigit():
+            return self._json({"error": "vehicle id must be an integer"}, 400)
+        self._json({"boxes": dataset_stats.boxes(int(vid), name),
+                    "class_names": dataset_stats.class_names()})
+
+    def _train_artifact(self) -> None:
+        """One picture ultralytics drew during this vehicle's last round.
+
+        The filename is checked against `train_artifacts.KINDS` rather than joined and
+        guarded: an allowlist cannot be traversed out of, and it also means a future
+        ultralytics release cannot quietly publish a new file over HTTP.
+        """
+        rel = self.path[len("/api/train-artifact/"):].split("?")[0]
+        vid, _, name = rel.partition("/")
+        if not vid.isdigit():
+            return self._json({"error": "vehicle id must be an integer"}, 400)
+        target = train_artifacts.artifact(int(vid), name)
         if target is None:
             return self._json({"error": "not found"}, 404)
         ctype = "image/png" if target.suffix.lower() == ".png" else "image/jpeg"

--- a/pipeline/static/README.md
+++ b/pipeline/static/README.md
@@ -13,6 +13,8 @@ reload. ES modules, no bundler, no CDN, no network at runtime.
 | Polling, heartbeat, GPU readouts, criteria, log stream | `js/live.js` | |
 | The fleet grid, the comparison and divergence charts | `js/fleet.js` | |
 | The per-vehicle drawer | `js/drawer.js` | |
+| The Data tab: counts, mixes, the shard table | `js/data.js` | |
+| Label boxes over a frame, and the trainer's own pictures | `js/consumed.js` | the only file that draws over an image |
 | Helpers, colours, condition glyphs | `js/util.js` | |
 | What the views share | `js/state.js` | one object, documented per field |
 | Wiring and startup | `js/main.js` | ~20 lines; if it grows, something is in the wrong file |
@@ -45,4 +47,13 @@ reload. ES modules, no bundler, no CDN, no network at runtime.
 | `GET /api/events` | SSE: log lines, stage transitions, signals |
 | `GET /api/vehicle/<vid>` | shard composition and sample image names |
 | `GET /api/shard-image/<vid>/<name>` | one image out of that vehicle's shard |
+| `GET /api/shard-labels/<vid>/<name>` | that frame's label rows, normalised, for the overlay |
+| `GET /api/train-artifacts` | which of the trainer's own pictures exist, per vehicle |
+| `GET /api/train-artifact/<vid>/<name>` | one of them; `<name>` must be in `train_artifacts.KINDS` |
 | `POST /api/run`, `POST /api/stop` | start and stop the one allowed run |
+
+The label overlay is an SVG on the unit square laid over the same `<img>` — the frame
+is never sent twice and nothing renders boxes server-side. That only works while the
+image element is not cropped, which is why `.strip .ovfig img` overrides
+`object-fit:cover`; `pipeline/tests/test_pipeline.py::test_label_overlay_boxes_land_where_the_label_file_says`
+runs the conversion under node and fails if a box moves.

--- a/pipeline/static/app.css
+++ b/pipeline/static/app.css
@@ -194,6 +194,34 @@ body[data-loaded="0"] .skel{color:transparent !important;border-radius:var(--r1)
 .strip{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
 .strip img{width:100%;aspect-ratio:16/9;object-fit:cover;border-radius:var(--r1);
            border:1px solid var(--line);background:var(--sunk)}
+/* ------------------------------------------------- what the trainer consumed
+   Two things: labels drawn over a shard frame, and the pictures ultralytics
+   already wrote. Both are photographs — they get a frame and a caption and no
+   other decoration, because the colour in them is data. */
+/* The overlay is stretched over the <img> box, so the <img> box has to BE the
+   image: `object-fit:cover` on .strip img would crop it and every box would sit
+   a few percent off. BDD100K is uniformly 16:9, so nothing visibly reflows. */
+.strip .ovfig img{aspect-ratio:auto;height:auto;object-fit:fill}
+.ovfig{position:relative;display:block}
+.ovfig svg{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
+.ovfig svg rect{pointer-events:auto}
+.ovfig figcaption{position:absolute;left:4px;bottom:4px;padding:0 4px;border-radius:var(--r1);
+                  background:rgba(4,7,11,.66);color:#e8eef6;
+                  font:600 var(--t-xs)/1.5 var(--mono)}
+.chiprow{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:var(--s3)}
+button.chip{background:none;color:var(--dim);cursor:pointer;border-color:var(--line)}
+button.chip[data-sel=true]{color:var(--accent);border-color:currentColor;background:var(--sunk)}
+button.chip:disabled{opacity:.35;cursor:not-allowed}
+.gallery{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:var(--s3)}
+.pairs{display:grid;gap:var(--s4)}
+.pair{display:grid;grid-template-columns:1fr 1fr;gap:var(--s3)}
+.pair h3{margin:0 0 4px;font:600 var(--t-xs)/1.4 var(--mono);text-transform:uppercase;
+         letter-spacing:.12em;color:var(--dim)}
+.shot img{width:100%;height:auto;display:block;border-radius:var(--r1);border:1px solid var(--line);
+          background:var(--sunk)}
+.shot figcaption{margin-top:4px;font:500 var(--t-xs)/1.4 var(--mono);color:var(--dim)}
+@media (max-width:820px){.pair{grid-template-columns:1fr}}
+
 .kvs{display:grid;grid-template-columns:1fr auto;gap:4px var(--s3);font-size:var(--t-sm)}
 .kvs dt{color:var(--dim)} .kvs dd{margin:0;font-family:var(--mono);font-variant-numeric:tabular-nums}
 

--- a/pipeline/static/js/consumed.js
+++ b/pipeline/static/js/consumed.js
@@ -1,0 +1,150 @@
+// What YOLO consumed, as pictures. Owns two things and nothing else:
+//
+//   1. the label overlay on a shard frame  — a unit-square SVG over the same <img>,
+//      so there is no second copy of the frame on the wire and no server-side
+//      drawing library anywhere in this project;
+//   2. the gallery of pictures ultralytics already drew during the last round.
+//
+// It draws nothing itself. Every image here came from the trainer or from the shard.
+import { $, esc, empty, PALETTE } from "./util.js";
+
+const seen = { names: [], boxes: new Map() };
+
+/** Cache is per frame, not per vehicle: switching vehicles back and forth is common. */
+async function boxesFor(vid, name) {
+  const key = `${vid}/${name}`;
+  if (seen.boxes.has(key)) return seen.boxes.get(key);
+  let d = { boxes: [] };
+  try {
+    d = await (await fetch(`/api/shard-labels/${encodeURIComponent(vid)}/${encodeURIComponent(name)}`)).json();
+  } catch { /* an unreachable server is already reported by the panel around this */ }
+  if (d.class_names && d.class_names.length) seen.names = d.class_names;
+  seen.boxes.set(key, d.boxes || []);
+  return d.boxes || [];
+}
+
+const cname = (c) => seen.names[c] || `class ${c}`;
+
+/** One frame with its labels drawn on it, or plain if `show` is false. */
+function figure(vid, name, boxes, show) {
+  const img = `<img loading="lazy" src="/api/shard-image/${encodeURIComponent(vid)}/${encodeURIComponent(name)}" ` +
+              `alt="A frame from vehicle ${esc(String(vid))}'s shard">`;
+  if (!show) return `<figure class="ovfig">${img}</figure>`;
+  // viewBox is the unit square and preserveAspectRatio is off, so the SVG stretches
+  // to whatever box the CSS gives the image. YOLO coordinates are already normalised,
+  // which is the whole reason this needs no pixel dimensions from anywhere.
+  const rects = boxes.map(b => {
+    const c = PALETTE[b.cls % PALETTE.length];
+    return `<rect x="${(b.cx - b.w / 2).toFixed(5)}" y="${(b.cy - b.h / 2).toFixed(5)}" ` +
+           `width="${b.w.toFixed(5)}" height="${b.h.toFixed(5)}" fill="none" stroke="${c}" ` +
+           `stroke-width="0.004" vector-effect="non-scaling-stroke"><title>${esc(cname(b.cls))}</title></rect>`;
+  }).join("");
+  return `<figure class="ovfig">${img}` +
+         `<svg viewBox="0 0 1 1" preserveAspectRatio="none" aria-hidden="true">${rects}</svg>` +
+         `<figcaption>${boxes.length} object${boxes.length === 1 ? "" : "s"}</figcaption></figure>`;
+}
+
+/**
+ * Render a strip of shard frames into `host`, optionally with the labels drawn.
+ * `names` comes from /api/vehicle/<vid>, which the caller already has.
+ */
+export async function renderStrip(host, vid, names, show) {
+  if (!host || vid == null) return;
+  const frames = (names || []).slice(0, 8);
+  if (!frames.length) {
+    host.innerHTML = '<p class="hint">No images materialised in this shard.</p>';
+    return;
+  }
+  const boxes = show ? await Promise.all(frames.map(n => boxesFor(vid, n))) : [];
+  host.innerHTML = frames.map((n, i) => figure(vid, n, boxes[i] || [], show)).join("");
+}
+
+// -- the trainer's own pictures ------------------------------------------------
+
+const state = { data: null, vid: null, group: "consumed" };
+
+const GROUPS = [
+  ["consumed", "batches as fed", "The images after mosaic, scaling and colour jitter — " +
+    "this is the tensor the network saw, not the file on disk."],
+  ["truth", "truth vs prediction", "Same frames, ground truth beside this vehicle's own " +
+    "prediction. Note what it misses, not only what it scores."],
+  ["quality", "where it fails", "Confusion, precision against recall, and this vehicle's " +
+    "own curves. All local: none of this is the aggregate on the holdout."],
+];
+
+export async function loadConsumed(vid) {
+  state.vid = vid;
+  const host = $("consumedBody");
+  if (!host) return;
+  if (!state.data) {
+    host.innerHTML = '<div class="skel-block" style="min-height:200px"></div>';
+    try {
+      state.data = await (await fetch("/api/train-artifacts")).json();
+    } catch {
+      host.innerHTML = empty("The server did not answer.", "Is <code>python -m pipeline.server</code> still running?");
+      return;
+    }
+  }
+  renderConsumed();
+}
+
+function tile(vid, f) {
+  return `<figure class="shot"><img loading="lazy" ` +
+    `src="/api/train-artifact/${encodeURIComponent(vid)}/${encodeURIComponent(f.name)}" ` +
+    `alt="${esc(f.caption)}"><figcaption>${esc(f.name)} — ${esc(f.caption)}</figcaption></figure>`;
+}
+
+function renderConsumed() {
+  const host = $("consumedBody");
+  const d = state.data;
+  if (!host || !d) return;
+  const list = d.vehicles || [];
+  if (!list.length) {
+    host.innerHTML = empty("No fleet on disk.", "Run the <code>fleet</code> stage, then reload.");
+    return;
+  }
+  const v = list.find(x => String(x.vid) === String(state.vid)) || list.find(x => x.files.length) || list[0];
+  state.vid = v.vid;
+
+  const picker = list.map(x =>
+    `<button class="chip" data-cvid="${x.vid}" data-sel="${String(x.vid) === String(v.vid)}" ` +
+    `${x.files.length ? "" : "disabled"} title="${x.files.length} artifacts">v${x.vid}</button>`).join("");
+  const tabs = GROUPS.map(([k, t]) =>
+    `<button class="chip" data-cgroup="${k}" data-sel="${k === state.group}">${t}</button>`).join("");
+
+  let body;
+  if (!v.files.length) {
+    body = empty(`Vehicle ${v.vid} has not trained yet.`,
+      "These pictures appear after that vehicle's first round.");
+  } else if (state.group === "truth") {
+    // Paired on purpose: a prediction image alone is a demo, the two together are
+    // evidence. Only pairs where both halves exist are shown.
+    const rows = (d.pairs || []).filter(([a, b]) =>
+      v.files.some(f => f.name === a) && v.files.some(f => f.name === b));
+    body = rows.length
+      ? '<div class="pairs">' + rows.map(([a, b]) =>
+          `<div class="pair"><div><h3>ground truth</h3>${tile(v.vid, {name: a, caption: "ground truth"})}</div>` +
+          `<div><h3>predicted</h3>${tile(v.vid, {name: b, caption: "predicted"})}</div></div>`).join("") + "</div>"
+      : empty("No validation images from that round.", "They appear once a round completes validation.");
+  } else {
+    const files = v.files.filter(f => f.group === state.group);
+    body = files.length
+      ? '<div class="gallery">' + files.map(f => tile(v.vid, f)).join("") + "</div>"
+      : empty("Nothing in this group yet.", "The last round wrote no such file.");
+  }
+
+  const blurb = (GROUPS.find(g => g[0] === state.group) || [])[2] || "";
+  host.innerHTML =
+    `<div class="chiprow">${picker}</div><div class="chiprow">${tabs}</div>` +
+    `<p class="hint">${esc(blurb)}</p>` + body +
+    `<p class="hint">Written by ultralytics itself, not by this project. The client passes ` +
+    `<code>exist_ok=True</code>, so each vehicle's directory holds only its <b>last</b> ` +
+    `round — this is a snapshot, never a history.</p>`;
+
+  host.querySelectorAll("[data-cvid]").forEach(b => b.onclick = () => {
+    state.vid = b.dataset.cvid; renderConsumed();
+  });
+  host.querySelectorAll("[data-cgroup]").forEach(b => b.onclick = () => {
+    state.group = b.dataset.cgroup; renderConsumed();
+  });
+}

--- a/pipeline/static/js/data.js
+++ b/pipeline/static/js/data.js
@@ -5,8 +5,10 @@
 // table highlight together — one selection, three views.
 import { $, esc, empty, glyph, PALETTE } from "./util.js";
 import { state } from "./state.js";
+import { renderStrip, loadConsumed } from "./consumed.js";
 
-const view = { data: null, shard: null, sort: { key: "vid", dir: 1 }, loading: false };
+const view = { data: null, shard: null, sort: { key: "vid", dir: 1 }, loading: false,
+               labels: true };
 
 export async function loadData(force) {
   if (view.loading) return;
@@ -164,14 +166,24 @@ function render() {
         `<p class="hint">It has to look like the data it measures. A holdout drawn from ` +
         `one condition would answer a different question than the one being asked.</p></div>` +
 
-      `<div class="panel"><h2>What ${sel ? "vehicle " + sel.vid : "the fleet"} sees</h2>` +
+      `<div class="panel"><h2>What ${sel ? "vehicle " + sel.vid : "the fleet"} sees` +
+        `<button class="chip" id="toggleLabels" data-sel="${view.labels}">` +
+        `${view.labels ? "labels on" : "labels off"}</button></h2>` +
         `<div class="strip" id="dataStrip"></div>` +
-        `<p class="hint">Frames from the shard itself. Select a vehicle in the table to ` +
-        `change them.</p></div>` +
-    `</div>`;
+        `<p class="hint">Frames from the shard itself, with the label file drawn over ` +
+        `them — the boxes are what the trainer reads, not a prediction. A frame whose ` +
+        `boxes sit in the wrong place is a broken shard, and no histogram would say so. ` +
+        `Select a vehicle in the table to change them.</p></div>` +
+    `</div>` +
+
+    `<div class="panel"><h2>What YOLO actually consumed` +
+      `<span class="n">drawn by ultralytics, during the run</span></h2>` +
+      `<div id="consumedBody"></div></div>`;
 
   wire();
-  loadStrip(sel ? sel.vid : (d.fleet[0] || {}).vid);
+  const vid = sel ? sel.vid : (d.fleet[0] || {}).vid;
+  loadStrip(vid);
+  loadConsumed(vid);
 }
 
 async function loadStrip(vid) {
@@ -180,10 +192,7 @@ async function loadStrip(vid) {
   host.innerHTML = '<div class="skel-block" style="min-height:80px"></div>';
   try {
     const v = await (await fetch(`/api/vehicle/${encodeURIComponent(vid)}`)).json();
-    host.innerHTML = (v.samples || []).slice(0, 8).map(n =>
-      `<img loading="lazy" src="/api/shard-image/${encodeURIComponent(vid)}/${encodeURIComponent(n)}" ` +
-      `alt="A frame from vehicle ${esc(String(vid))}'s shard">`).join("") ||
-      '<p class="hint">No images materialised in this shard.</p>';
+    await renderStrip(host, vid, v.samples, view.labels);
   } catch {
     host.innerHTML = '<p class="hint">Could not load frames.</p>';
   }
@@ -205,6 +214,15 @@ function wire() {
   });
   const clear = $("clearShard");
   if (clear) clear.onclick = () => { view.shard = null; render(); };
+  const toggle = $("toggleLabels");
+  // Re-renders the strip only. A full render() would refetch nothing but would throw
+  // away the consumed panel's own vehicle/group selection.
+  if (toggle) toggle.onclick = () => {
+    view.labels = !view.labels;
+    toggle.dataset.sel = String(view.labels);
+    toggle.textContent = view.labels ? "labels on" : "labels off";
+    loadStrip(view.shard ?? ((view.data.fleet[0] || {}).vid));
+  };
   const refresh = $("dataRefresh");
   if (refresh) refresh.onclick = () => loadData(true);
 }

--- a/pipeline/tests/js/overlay_geometry.mjs
+++ b/pipeline/tests/js/overlay_geometry.mjs
@@ -1,0 +1,45 @@
+// Renders the strip against a fake DOM and asserts the overlay geometry.
+//
+// A box drawn a few percent off looks plausible and is worse than no box at all:
+// the whole point of the overlay is to be trusted when it says a shard's labels are
+// wrong. The conversion is four subtractions and this asserts all four.
+//
+// Run by pipeline/tests/test_pipeline.py, which copies the dashboard's js/ next to
+// this file first — hence the bare `./consumed.js` import. `node overlay_geometry.mjs`
+// on its own will not resolve it.
+globalThis.document = { getElementById: () => null, querySelectorAll: () => [] };
+globalThis.fetch = async (url) => ({ json: async () => ({
+  class_names: ["person","rider","car"],
+  boxes: [{cls:2, cx:0.5, cy:0.5, w:0.25, h:0.5}, {cls:0, cx:0.1, cy:0.9, w:0.2, h:0.2}],
+})});
+const { renderStrip } = await import("./consumed.js");
+
+const host = { innerHTML: "" };
+await renderStrip(host, 7, ["a.jpg", "b.jpg"], true);
+const h = host.innerHTML;
+
+const rect = h.match(/<rect x="([\d.]+)" y="([\d.]+)" width="([\d.]+)" height="([\d.]+)"/);
+console.assert(rect, "no rect drawn");
+const [, x, y, w, hh] = rect.map(Number);
+// cx .5 cy .5 w .25 h .5  ->  x .375  y .25  w .25  h .5
+console.assert(Math.abs(x - 0.375) < 1e-6, `x ${x}`);
+console.assert(Math.abs(y - 0.25) < 1e-6, `y ${y}`);
+console.assert(Math.abs(w - 0.25) < 1e-6, `w ${w}`);
+console.assert(Math.abs(hh - 0.5) < 1e-6, `h ${hh}`);
+console.assert(h.includes("<title>car</title>"), "class name not in the tooltip");
+console.assert((h.match(/<figure class="ovfig">/g) || []).length === 2, "not 2 figures");
+console.assert((h.match(/<rect /g) || []).length === 4, "not 2 boxes per figure");
+console.assert(h.includes('viewBox="0 0 1 1"'), "overlay is not a unit square");
+console.assert(h.includes("2 objects"), "no count caption");
+
+// labels off: the same frames, no overlay at all.
+const plain = { innerHTML: "" };
+await renderStrip(plain, 7, ["a.jpg"], false);
+console.assert(!plain.innerHTML.includes("<svg"), "overlay drawn when labels are off");
+console.assert(plain.innerHTML.includes("/api/shard-image/7/a.jpg"), "frame url wrong");
+
+// an empty shard says so instead of rendering nothing.
+const none = { innerHTML: "" };
+await renderStrip(none, 7, [], true);
+console.assert(none.innerHTML.includes("No images materialised"), "empty shard unexplained");
+console.log("overlay geometry, tooltips, counts, toggle and empty state: OK");

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import re
 import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -362,6 +363,89 @@ def test_every_file_the_dashboard_imports_is_servable():
     for js in (server.STATIC / "js").glob("*.js"):
         for imported in re.findall(r'from "\./([^"]+)"', js.read_text(encoding="utf-8")):
             assert (server.STATIC / "js" / imported).is_file(), f"{js.name} imports missing {imported}"
+
+
+def test_label_overlay_boxes_land_where_the_label_file_says(tmp_path):
+    """The one piece of geometry in the dashboard, checked by running it.
+
+    `cx cy w h` centred becomes `x y w h` cornered, and a box drawn a few percent off
+    is worse than no box: the overlay exists to be believed when it says a shard is
+    mislabelled. Skipped rather than failed without node — the dashboard is served as
+    plain files and this repo has no other JS toolchain.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not installed; the overlay geometry is unchecked here")
+
+    from pipeline import server
+    work = tmp_path / "js"
+    shutil.copytree(server.STATIC / "js", work)
+    (work / "package.json").write_text('{"type":"module"}')
+    check = Path(__file__).parent / "js" / "overlay_geometry.mjs"
+    shutil.copy(check, work / check.name)
+
+    # console.assert writes to stderr and does NOT set the exit code, so an assertion
+    # that fires would otherwise pass silently -- the exact class of bug this repo
+    # keeps shipping. Both conditions are checked.
+    out = subprocess.run([node, str(work / check.name)], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert "Assertion failed" not in out.stderr, out.stderr
+    assert "OK" in out.stdout, out.stdout
+
+
+def test_train_artifact_route_serves_only_names_on_the_allowlist(tmp_path, monkeypatch):
+    """The trainer's directory holds weights and a data yaml beside the pictures.
+
+    Names are matched against `KINDS` rather than joined onto the run directory and
+    guarded, so neither `../../CLAUDE.md` nor `weights/best.pt` can be fetched — and a
+    future ultralytics release cannot publish a new file over HTTP by writing it.
+    """
+    from pipeline import train_artifacts
+
+    run = tmp_path / "my-project" / "runs" / "detect" / "runs" / "fl" / "batch3"
+    run.mkdir(parents=True)
+    (run / "args.yaml").write_text("epochs: 1")
+    (run / "labels.jpg").write_bytes(b"\xff\xd8jpeg")
+    (run / "weights").mkdir()
+    (run / "weights" / "best.pt").write_bytes(b"weights")
+    monkeypatch.setattr(train_artifacts.paths, "PROJECT", tmp_path / "my-project")
+
+    assert train_artifacts.run_dir(3) == run
+    assert train_artifacts.artifact(3, "labels.jpg") == run / "labels.jpg"
+    assert train_artifacts.artifact(3, "weights/best.pt") is None
+    assert train_artifacts.artifact(3, "../../../CLAUDE.md") is None
+    assert train_artifacts.artifact(3, "args.yaml") is None
+    assert train_artifacts.artifact(4, "labels.jpg") is None      # no such vehicle
+    # train_batch0.jpg is on the allowlist but was not written: absent, not an error.
+    assert train_artifacts.artifact(3, "train_batch0.jpg") is None
+
+    listed = train_artifacts.for_vehicle(3)
+    assert [f["name"] for f in listed["files"]] == ["labels.jpg"]
+
+
+def test_shard_label_boxes_are_normalised_and_a_bad_row_does_not_lose_the_good_ones(
+        tmp_path, monkeypatch):
+    """A label file with one broken row still has good rows.
+
+    Raising here would blank the overlay for the whole frame, which is exactly the
+    frame someone is looking at *because* they suspect its labels.
+    """
+    from pipeline import dataset_stats
+
+    labels = tmp_path / "batch_7" / "labels" / "train"
+    labels.mkdir(parents=True)
+    (labels / "frame.txt").write_text(
+        "2 0.5 0.5 0.25 0.5\n"        # good
+        "9 0.1 0.2\n"                  # too few fields
+        "car 0.1 0.2 0.3 0.4\n"        # class is not a number
+        "0 0.9 0.9 0.05 0.05\n"        # good, and last
+    )
+    monkeypatch.setattr(dataset_stats.paths, "VEHICLE_BATCHES", tmp_path)
+
+    got = dataset_stats.boxes(7, "frame.jpg")
+    assert [b["cls"] for b in got] == [2, 0]
+    assert got[0] == {"cls": 2, "cx": 0.5, "cy": 0.5, "w": 0.25, "h": 0.5}
+    assert dataset_stats.boxes(7, "no-such-frame.jpg") == []
 
 
 def test_shard_composition_counts_what_the_vehicle_actually_holds(tmp_path, monkeypatch):

--- a/pipeline/train_artifacts.py
+++ b/pipeline/train_artifacts.py
@@ -1,0 +1,133 @@
+"""What YOLO actually consumed, as pictures rather than as counts.
+
+`dataset_stats` answers *how much* of each class a shard holds. It cannot answer the
+question a wrong run always turns out to hinge on: **is the model looking at what we
+think it is looking at?** Mosaic augmentation, letterboxing, a label file whose class
+ids are off by one, a shard whose "night" images are daytime — none of that is visible
+in a histogram, and all of it is visible in one glance at a batch.
+
+Ultralytics already draws every one of those pictures. Each client's `train()` writes
+them beside its checkpoints and nothing has ever looked at them:
+
+    train_batch{0,1,2}.jpg      the real batches, post-augmentation, boxes drawn
+    labels.jpg                  class counts + box size/position distributions
+    val_batch{n}_labels.jpg     ground truth on the val split
+    val_batch{n}_pred.jpg       this model's predictions on the same images
+    confusion_matrix*.png       which classes it confuses for which
+    Box{P,R,F1,PR}_curve.png    precision/recall against confidence
+    results.png                 the loss and metric curves for this vehicle
+
+So this module writes nothing and renders nothing. It locates those files per vehicle
+and hands them to the dashboard. Assemble before building, rule 4.
+
+Two caveats the dashboard repeats to the reader, because a picture is persuasive in a
+way a number is not:
+
+- the client passes ``exist_ok=True``, so a vehicle's directory holds only its **last**
+  round. These are not a history.
+- ``val_batch*_pred.jpg`` is that client's local model on its *own* val split, not the
+  aggregate on the holdout. It is the flattering number made visual.
+
+    python -m pipeline.train_artifacts        # what exists, per vehicle
+"""
+from __future__ import annotations
+
+import argparse
+
+from . import paths, vehicles
+
+#: filename -> (group, what it proves). Order is the display order. Anything the
+#: trainer writes that is not in here is not served: an allowlist, so a future
+#: ultralytics version cannot expose a new file by URL without a decision here.
+KINDS: dict[str, tuple[str, str]] = {
+    "train_batch0.jpg": ("consumed", "a real training batch, after mosaic and augmentation"),
+    "train_batch1.jpg": ("consumed", "a real training batch, after mosaic and augmentation"),
+    "train_batch2.jpg": ("consumed", "a real training batch, after mosaic and augmentation"),
+    "labels.jpg": ("consumed", "class counts, and where the boxes sit in the frame"),
+    "val_batch0_labels.jpg": ("truth", "ground truth on this vehicle's val split"),
+    "val_batch0_pred.jpg": ("pred", "what this vehicle's local model predicted there"),
+    "val_batch1_labels.jpg": ("truth", "ground truth on this vehicle's val split"),
+    "val_batch1_pred.jpg": ("pred", "what this vehicle's local model predicted there"),
+    "val_batch2_labels.jpg": ("truth", "ground truth on this vehicle's val split"),
+    "val_batch2_pred.jpg": ("pred", "what this vehicle's local model predicted there"),
+    "confusion_matrix_normalized.png": ("quality", "which classes it mistakes for which"),
+    "BoxPR_curve.png": ("quality", "precision against recall, per class"),
+    "BoxF1_curve.png": ("quality", "F1 against confidence — where to set the threshold"),
+    "results.png": ("quality", "this vehicle's own loss and metric curves"),
+}
+
+#: The pairs the dashboard shows side by side. Truth on the left, prediction on the
+#: right, same images — the only honest way to look at a detector.
+PAIRS = [(f"val_batch{n}_labels.jpg", f"val_batch{n}_pred.jpg") for n in range(3)]
+
+
+def run_dir(vid: int):
+    """The ultralytics run directory for one vehicle, or None.
+
+    Globbed rather than constructed. The client passes ``project="runs/fl"`` relative
+    to its own CWD, and ultralytics resolves that against its ``runs_dir`` setting —
+    which is why the path on this machine is `runs/detect/runs/fl/batch1` and would be
+    `runs/fl/batch1` on a machine whose settings were never touched. Constructing it
+    would work here and break for anyone reproducing the project.
+    """
+    found = [d for d in paths.PROJECT.glob(f"runs/**/batch{int(vid)}")
+             if d.is_dir() and (d / "args.yaml").exists()]
+    return max(found, key=lambda d: d.stat().st_mtime, default=None)
+
+
+def artifact(vid: int, name: str):
+    """``name`` inside that vehicle's run directory, if it is one we serve."""
+    if name not in KINDS:
+        return None
+    root = run_dir(vid)
+    if root is None:
+        return None
+    target = root / name
+    return target if target.is_file() else None
+
+
+def for_vehicle(vid: int) -> dict:
+    root = run_dir(vid)
+    if root is None:
+        return {"vid": vid, "dir": None, "files": []}
+    files = []
+    for name, (group, caption) in KINDS.items():
+        f = root / name
+        if f.is_file():
+            files.append({"name": name, "group": group, "caption": caption,
+                          "mtime": int(f.stat().st_mtime)})
+    return {"vid": vid, "dir": str(root), "files": files}
+
+
+def listing() -> dict:
+    """Every vehicle in the current fleet, with whatever its last round left behind.
+
+    Keyed off the fleet rather than off the directories on disk, so a vehicle that has
+    never trained shows up as empty instead of silently missing — the distinction
+    between "no artifacts" and "no such vehicle" is the one worth seeing.
+    """
+    fleet = vehicles.load_fleet()
+    return {
+        "pairs": [list(p) for p in PAIRS],
+        "vehicles": [{**for_vehicle(int(v["vid"])),
+                      "condition": v.get("condition")} for v in fleet if v.get("vid") is not None],
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.parse_args(argv)
+    d = listing()
+    if not d["vehicles"]:
+        print("no fleet on disk — run the fleet stage first")
+        return 1
+    for v in d["vehicles"]:
+        where = v["dir"] or "never trained"
+        print(f"v{v['vid']:<3} {str(v.get('condition') or '')[:26]:<28} "
+              f"{len(v['files']):>2} artifacts  {where}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What was wrong or missing

The Data tab could say a shard holds 6 308 objects, 55.4 % of them cars. It could not say whether those boxes sit anywhere near the cars, and no histogram ever will. Every silent failure in `CLAUDE.md` was of that shape: the numbers were fine and the thing underneath them was not.

Meanwhile ultralytics has been writing **14 pictures per vehicle per round** into its run directory since the first federation — the real batches after mosaic and augmentation, the label distribution, ground truth beside that vehicle's own prediction, the confusion matrix, the PR and F1 curves. Nothing had ever looked at them.

```
$ python -m pipeline.train_artifacts
v1   daytime city                 14 artifacts  .../runs/detect/runs/fl/batch1
v4   highway                       0 artifacts  never trained
```

## What changed

- **Label overlay.** Shard frames in the Data tab now carry their label file drawn over them, with a `labels on/off` toggle. YOLO labels are already normalised, so the overlay is an SVG on the unit square over the same `<img>`: the frame is not sent twice, no image library enters the project, and the toggle costs no refetch. `.strip .ovfig img` must override `object-fit:cover` or the crop moves every box a few percent — plausible-looking, which is worse than drawing nothing.
- **`pipeline/train_artifacts.py`** locates each vehicle's run directory by **glob**, not construction: the path depends on that machine's ultralytics `runs_dir` setting, so constructing it would work here and break for anyone reproducing the project. Filenames are matched against an **allowlist**, not joined-and-guarded, so `weights/best.pt` cannot be fetched and a future ultralytics release cannot publish a new file over HTTP by writing one.
- **Three routes**: `/api/shard-labels/<vid>/<name>`, `/api/train-artifacts`, `/api/train-artifact/<vid>/<name>`.
- **`static/js/consumed.js`** — the overlay plus a gallery grouped as *batches as fed* / *truth vs prediction* / *where it fails*.
- **`docs/OSS_TOOLING_REVIEW.md`** — what was weighed and refused.

**Deliberately not changed:** nothing in `my-project/`. Nothing renders images server-side. No new dependency: FiftyOne would cost a MongoDB process and a second port to show pictures already on disk (deferred to phase 4, where its embedding search is the only tool that can do the job); `supervision` would draw server-side what the browser draws for free; Rerun would need logging inside the ⚠ client.

## How it was verified

```
$ python -m pytest my-project/tests pipeline/tests -q
152 passed in 2.70s
```

Three new tests:
- the allowlist refuses `weights/best.pt`, `args.yaml` and `../../../CLAUDE.md`
- a label file with two malformed rows still yields its two good ones
- the overlay geometry is **executed** under node against a fake DOM

The geometry test was mutated (`b.w / 2` → `b.w / 3`) and **failed**, then restored and passed. A check that cannot fail is not a check.

Live, against a running server:

```
labels.jpg                        200 image/jpeg 129 949 B
confusion_matrix_normalized.png   200 image/png  289 765 B
weights/best.pt                   404
../../../CLAUDE.md                404
/api/shard-labels/1/00091078-7cff8ea6.jpg -> 23 boxes, 0 outside [0,1]
```

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke — not yet run on this branch
- [x] Docs updated in this PR (`CLAUDE.md`, `pipeline/static/README.md`, `docs/OSS_TOOLING_REVIEW.md`, `docs/prompts/`)
- [x] No data, checkpoints, reports or credentials staged
- [x] `my-project/pyproject.toml` not committed in its flwr-rewritten form
- [ ] `STATUS.md` — not touched here; the stack's status lands with the last PR

## Still open

- **The rendered page is unverified.** Both browser automation paths were unavailable in the session that wrote this (extension not connected; devtools profile in use). Routes, geometry and every empty state are covered by tests; the visual result is not. Worth one look before merge.
- The prompt in `docs/prompts/2026-08-16-data-consumption-view.md` was written **after** the code and says so. The rejected options in it were genuinely weighed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)