### PR TITLE
feat(dashboard): show the batch the vehicle on the GPU is working through

### DIFF
--- a/pipeline/static/index.html
+++ b/pipeline/static/index.html
@@ -157,6 +157,11 @@
   </div>
 
   <div class="panel">
+    <h2>On the glass right now <span class="n" id="nowTrainingWho">idle</span></h2>
+    <div id="nowTraining"></div>
+  </div>
+
+  <div class="panel">
     <h2>Honest global metric <span class="n">measured on data no vehicle trained on</span></h2>
     <div class="grid two" style="grid-template-columns:minmax(220px,300px) 1fr;align-items:center">
       <div class="readouts">

--- a/pipeline/static/js/consumed.js
+++ b/pipeline/static/js/consumed.js
@@ -59,6 +59,51 @@ export async function renderStrip(host, vid, names, show) {
   host.innerHTML = frames.map((n, i) => figure(vid, n, boxes[i] || [], show)).join("");
 }
 
+// -- the live feed ------------------------------------------------------------
+//
+// Ultralytics rewrites train_batch{0,1,2}.jpg at the start of every `train()`, and a
+// round is one `train()` per vehicle. So the file on disk IS the batch the vehicle
+// currently on the GPU is working through — no instrumentation, no hook, nothing
+// added to the ⚠ client. The mtime is the cache-buster: same URL, new picture.
+
+const feed = { at: 0, data: null, vid: null };
+const FEED_MS = 5000;   // the page polls every 2s; re-globbing ten run dirs that often
+                        // is filesystem work for a picture that changes once a round.
+
+export async function renderNowTraining(host, who, whoLabel, busy) {
+  if (!host) return;
+  if (!busy || who == null) {
+    host.innerHTML = '<p class="hint">Nothing is training. During a run this shows the ' +
+      'batch the vehicle on the GPU is working through — the same file ultralytics ' +
+      'writes for itself, not a re-render.</p>';
+    feed.at = 0;
+    return;
+  }
+  const now = performance.now();
+  if (now - feed.at > FEED_MS || feed.vid !== String(who)) {
+    feed.at = now;
+    feed.vid = String(who);
+    try {
+      feed.data = await (await fetch("/api/train-artifacts")).json();
+    } catch { return; }
+  }
+  const v = ((feed.data || {}).vehicles || []).find(x => String(x.vid) === String(who));
+  const shots = (v ? v.files : []).filter(f => f.group === "consumed" && f.name.startsWith("train_batch"));
+  if (!shots.length) {
+    host.innerHTML = `<p class="hint">${esc(whoLabel)} has started, but has not written its ` +
+      `first batch mosaic yet. It appears within the first epoch.</p>`;
+    return;
+  }
+  host.innerHTML = '<div class="gallery">' + shots.map(f =>
+    `<figure class="shot"><img src="/api/train-artifact/${encodeURIComponent(who)}/` +
+    `${encodeURIComponent(f.name)}?t=${f.mtime}" alt="${esc(f.caption)}">` +
+    `<figcaption>${esc(f.name)}</figcaption></figure>`).join("") + "</div>" +
+    `<p class="hint">Mosaic, scale and colour jitter are already applied: this is the ` +
+    `tensor, not the files on disk. Written by the trainer itself — if these stop ` +
+    `changing between rounds while the run continues, the vehicle is not re-reading ` +
+    `its shard.</p>`;
+}
+
 // -- the trainer's own pictures ------------------------------------------------
 
 const state = { data: null, vid: null, group: "consumed" };

--- a/pipeline/static/js/live.js
+++ b/pipeline/static/js/live.js
@@ -4,6 +4,7 @@ import { lineChart } from "./chart.js";
 import { state } from "./state.js";
 import { renderStages, renderOptions } from "./control.js";
 import { renderFleet } from "./fleet.js";
+import { renderNowTraining } from "./consumed.js";
 
 const POLL_MS = 2000;
 
@@ -18,6 +19,8 @@ export async function poll() {
     renderOptions(s.options);
     renderGpu(s.gpu);
     renderLive(s.live, s.config);
+    renderNowTraining($("nowTraining"), s.live && s.live.training_now,
+                      nowLabel(s), s.busy);
     renderReports(s.reports);
     renderFleet();
     document.body.dataset.loaded = "1";
@@ -31,6 +34,16 @@ export async function poll() {
     /* the server is restarting; the next tick catches up */
   }
   setTimeout(poll, POLL_MS);
+}
+
+/** "vehicle 3 · rain / fog", and the same string into the panel's own subtitle. */
+function nowLabel(s) {
+  const who = s.live && s.live.training_now;
+  const v = who == null ? null : (s.fleet || []).find(x => String(x.vid) === String(who));
+  const label = who == null ? (s.busy ? "between vehicles" : "idle")
+    : `vehicle ${who}${v && v.condition ? " · " + v.condition : ""}`;
+  $("nowTrainingWho").textContent = label;
+  return label;
 }
 
 function renderLive(L, cfg) {

--- a/pipeline/tests/js/live_feed.mjs
+++ b/pipeline/tests/js/live_feed.mjs
@@ -1,0 +1,54 @@
+// The live batch feed, against a fake DOM.
+//
+// Three states, and the boring ones are the ones that go wrong: idle must explain
+// itself rather than render an empty box, a vehicle that has started but not yet
+// written a mosaic must say so rather than show the previous vehicle's, and the
+// image URL must carry the mtime or the browser serves the last round's picture
+// from cache for the whole run.
+globalThis.document = { getElementById: () => null, querySelectorAll: () => [] };
+globalThis.performance = { now: () => 0 };
+
+const LISTING = {
+  pairs: [],
+  vehicles: [
+    { vid: 3, condition: "rain / fog", dir: "runs/fl/batch3", files: [
+      { name: "train_batch0.jpg", group: "consumed", caption: "a batch", mtime: 1786020949 },
+      { name: "train_batch1.jpg", group: "consumed", caption: "a batch", mtime: 1786020950 },
+      { name: "labels.jpg", group: "consumed", caption: "class counts", mtime: 1786020951 },
+      { name: "val_batch0_pred.jpg", group: "pred", caption: "predicted", mtime: 1786020952 },
+    ]},
+    { vid: 4, condition: "highway", dir: null, files: [] },
+  ],
+};
+globalThis.fetch = async () => ({ json: async () => LISTING });
+
+const { renderNowTraining } = await import("./consumed.js");
+
+// idle
+const idle = { innerHTML: "" };
+await renderNowTraining(idle, null, "idle", false);
+console.assert(!idle.innerHTML.includes("<img"), "rendered an image while idle");
+console.assert(idle.innerHTML.includes("Nothing is training"), "idle state is silent");
+
+// training, with mosaics on disk
+const live = { innerHTML: "" };
+await renderNowTraining(live, 3, "vehicle 3 · rain / fog", true);
+const imgs = live.innerHTML.match(/<img src="([^"]+)"/g) || [];
+console.assert(imgs.length === 2, `expected the 2 train_batch files, got ${imgs.length}`);
+console.assert(!live.innerHTML.includes("labels.jpg"), "labels.jpg is not a batch mosaic");
+console.assert(!live.innerHTML.includes("val_batch0_pred"), "a prediction is not what it consumed");
+console.assert(live.innerHTML.includes("train_batch0.jpg?t=1786020949"),
+  "the mtime is missing from the URL, so the browser will serve a stale round");
+
+// started, nothing written yet
+const early = { innerHTML: "" };
+await renderNowTraining(early, 4, "vehicle 4 · highway", true);
+console.assert(!early.innerHTML.includes("<img"), "showed an image for a vehicle with none");
+console.assert(early.innerHTML.includes("not written its"), "no explanation for the gap");
+
+// a vehicle the listing has never heard of behaves like the one above, not like a crash
+const unknown = { innerHTML: "" };
+await renderNowTraining(unknown, 99, "vehicle 99", true);
+console.assert(!unknown.innerHTML.includes("<img"), "invented an image for an unknown vehicle");
+
+console.log("live feed: idle, training, not-yet-written and unknown vehicle all OK");

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -365,32 +365,54 @@ def test_every_file_the_dashboard_imports_is_servable():
             assert (server.STATIC / "js" / imported).is_file(), f"{js.name} imports missing {imported}"
 
 
-def test_label_overlay_boxes_land_where_the_label_file_says(tmp_path):
-    """The one piece of geometry in the dashboard, checked by running it.
+def _run_js_check(tmp_path, name: str) -> None:
+    """Run one of `pipeline/tests/js/*.mjs` against the real dashboard modules.
 
-    `cx cy w h` centred becomes `x y w h` cornered, and a box drawn a few percent off
-    is worse than no box: the overlay exists to be believed when it says a shard is
-    mislabelled. Skipped rather than failed without node — the dashboard is served as
-    plain files and this repo has no other JS toolchain.
+    The dashboard is served as plain files with no build step, so there is no JS test
+    runner here and adding one would be a larger change than the code it guards. The
+    modules are copied beside the check with a `type: module` marker, which is all
+    node needs to import them.
+
+    Skipped rather than failed without node — but note that GitHub's runners ship it,
+    so CI does execute these.
     """
     node = shutil.which("node")
     if node is None:
-        pytest.skip("node not installed; the overlay geometry is unchecked here")
+        pytest.skip(f"node not installed; {name} is unchecked here")
 
     from pipeline import server
     work = tmp_path / "js"
     shutil.copytree(server.STATIC / "js", work)
     (work / "package.json").write_text('{"type":"module"}')
-    check = Path(__file__).parent / "js" / "overlay_geometry.mjs"
-    shutil.copy(check, work / check.name)
+    shutil.copy(Path(__file__).parent / "js" / name, work / name)
 
     # console.assert writes to stderr and does NOT set the exit code, so an assertion
     # that fires would otherwise pass silently -- the exact class of bug this repo
-    # keeps shipping. Both conditions are checked.
-    out = subprocess.run([node, str(work / check.name)], capture_output=True, text=True)
+    # keeps shipping. All three conditions are checked.
+    out = subprocess.run([node, str(work / name)], capture_output=True, text=True)
     assert out.returncode == 0, out.stderr
     assert "Assertion failed" not in out.stderr, out.stderr
     assert "OK" in out.stdout, out.stdout
+
+
+def test_label_overlay_boxes_land_where_the_label_file_says(tmp_path):
+    """`cx cy w h` centred becomes `x y w h` cornered.
+
+    A box drawn a few percent off looks plausible, and the overlay exists to be
+    believed when it says a shard is mislabelled. So the conversion is executed, not
+    read.
+    """
+    _run_js_check(tmp_path, "overlay_geometry.mjs")
+
+
+def test_the_live_feed_says_what_it_is_showing_in_every_state(tmp_path):
+    """Idle, training, started-but-nothing-written, and a vehicle nobody has heard of.
+
+    The failure that matters is the quiet one: without the mtime in the image URL the
+    browser serves round 1's mosaic for the whole run, and the panel looks alive while
+    showing a fossil.
+    """
+    _run_js_check(tmp_path, "live_feed.mjs")
 
 
 def test_train_artifact_route_serves_only_names_on_the_allowlist(tmp_path, monkeypatch):


### PR DESCRIPTION
> **Stacked on #33.** Review that one first; this branch's diff against it is small.

## What was wrong or missing

The Live view narrated a run in numbers — checksums, mAP, GPU utilisation, a log stream — and never once showed the data. There was no way to see what the vehicle currently on the GPU was actually looking at.

## What changed

One panel, *"On the glass right now"*, showing the `train_batch{0,1,2}.jpg` of the vehicle currently training.

Nothing is instrumented to produce it. Ultralytics rewrites those files at the start of every `train()`, and a round is one `train()` per vehicle, so the file on disk already **is** the batch being consumed — mosaic, scaling and colour jitter applied, which is the tensor rather than the files on disk. That is why this cost no change inside `my-project/`.

The **mtime is the cache-buster**. Without it the browser serves round 1's mosaic for the entire run and the panel looks alive while showing a fossil — a quiet failure of exactly the kind this repo keeps cataloguing, so it has its own assertion.

The listing is refetched at most every 5 s rather than on every 2 s poll: it globs ten run directories and the picture behind it changes once a round.

**Deliberately not changed:** `labels.jpg` and `val_batch*_pred.jpg` are excluded from this panel. Neither is a batch that was consumed, and showing a prediction next to "what it is training on" would invite the wrong reading.

## How it was verified

```
$ python -m pytest my-project/tests pipeline/tests -q
153 passed in 1.97s
```

A new node check covers four states, and the boring ones are the point: idle explains itself instead of rendering an empty box, a vehicle that has started but written nothing says so instead of showing the *previous* vehicle's mosaic, and an unknown vehicle does not invent one.

Deleting `?t=${f.mtime}` from the image URL makes that check **FAIL**; restored, it passes.

Confirmed against the running server:

```
id="nowTraining" in served index.html: True
id="nowTrainingWho" in served index.html: True
live.js imports the feed: True
```

The two node checks now share one runner, `_run_js_check`, which skips when node is absent. GitHub's runners ship node, so CI executes both.

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke — not yet run on this branch
- [x] Docs updated in this PR
- [x] No data, checkpoints, reports or credentials staged
- [x] `my-project/pyproject.toml` not committed in its flwr-rewritten form
- [ ] `STATUS.md` — lands with the last PR in the stack

## Still open

- **Never seen during an actual run.** The panel's states are covered by the node check, but no federation has been started with this branch checked out. The idle path is what was exercised live.
- Browser rendering unverified, same reason as #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)