### PR TITLE
build: a CPU container that runs this project's checks on someone else's machine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# The build context is the one place a "data is never committed" rule can be quietly
+# bypassed: nothing here is committed, and all of it would still end up in the image.
+# So this file is a safety rule, not an optimisation — read it that way.
+
+# -- data, in every form it takes here ---------------------------------------
+**/images/
+**/*.jpg
+**/*.jpeg
+**/*.png
+pipeline/vehicles/
+pipeline/holdout/
+full_data_run/
+json_to_yolo/
+
+# -- weights and checkpoints --------------------------------------------------
+**/*.pt
+**/*.pth
+**/*.onnx
+**/*.torchscript
+**/weights/
+checkpoints/
+models/
+
+# -- generated: runs, logs, trackers, caches ----------------------------------
+**/runs/
+**/logs/
+**/mlruns/
+pipeline/.state/
+pipeline/reports/
+**/*.cache
+**/__pycache__/
+.pytest_cache/
+
+# -- the repo's own plumbing --------------------------------------------------
+# `docs/` and `.github/` deliberately stay: tests assert that the docs index finds
+# real files and that the workflow references real paths. Excluding them made the
+# suite fail inside the image and pass outside it, which is the worst of both.
+.git/
+.vscode/
+Research_docs/
+*.ipynb
+
+# my-project/batch/*/labels and the split lists ARE committed and ARE needed: the
+# pipeline tests assert against real shard layouts. They are text, and they stay.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# The CPU reproduction path, containerised.
+#
+# What this image is FOR: running this project's checks on a machine that is not this
+# machine. `docker build` then `docker run` gives you both test suites — 33 in
+# my-project, 118 in pipeline — with no venv, no CUDA, and none of the Windows traps
+# that make a fresh clone here cost an hour.
+#
+# What it is NOT for, stated up front so nobody discovers it by wasting an afternoon:
+#
+#   * It cannot train. There is no CUDA here and no GPU passthrough configured. Torch
+#     is the CPU wheel deliberately — the whole point is a small image that runs
+#     everywhere, and this project's real runs need a Blackwell card and cu128.
+#   * It has no data. BDD100K is 7.6 GB in a kagglehub cache and this repo's first
+#     hard rule is that data is never committed; `.dockerignore` enforces that the
+#     build context cannot smuggle any in. A container that trained on nothing would
+#     be worse than one that says it cannot train.
+#   * It is therefore not a deployment. Flower's Deployment Engine (SuperLink +
+#     SuperNodes over gRPC+TLS) is configured in my-project/pyproject.toml under
+#     `[tool.flwr.federations.remote-deployment]` and is a different exercise.
+#
+# Size, measured rather than guessed: 2.05 GB. The CPU torch wheel is most of it and
+# `my-project/batch/*/labels` — ten shards of committed label text, ~291 MB — is the
+# rest. Those are real repo content, not data that slipped past .dockerignore: the
+# image contains zero .jpg and zero .pt, asserted after the build. Trimming them would
+# mean first establishing which tests read a real shard layout, and 291 MB of a 2 GB
+# image is not worth finding that out wrong.
+#
+# Build and run:
+#   docker build -t federated-yolov8:cpu .
+#   docker run --rm federated-yolov8:cpu                     # both suites
+#   docker run --rm federated-yolov8:cpu pytest pipeline/tests -q
+#   docker run --rm -it federated-yolov8:cpu bash            # poke at it
+
+FROM python:3.12-slim
+
+# 3.12 and not 3.13 for the same reason CI pins it: flwr[simulation] pulls ray, whose
+# dependency marker is python>=3.11,<3.13.
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    # flwr >= 1.31 otherwise builds its own runtime env with `uv sync` and reinstalls
+    # torch from PyPI, discarding the CPU wheel pinned below. On a real host that
+    # silently costs 5.5x the wall clock; here it would just bloat the image.
+    FLWR_DISABLE_RUNTIME_DEPENDENCY_INSTALLATION=1
+
+WORKDIR /repo
+
+# Dependencies before source, so editing a .py file does not re-download torch.
+# Mirrors CI's two install steps exactly: if this drifts from .github/workflows/ci.yml
+# then a green container stops meaning a green CI.
+RUN pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
+ && pip install --no-cache-dir flwr numpy pyyaml pytest
+
+COPY . /repo
+
+# `pytest my-project/tests` imports `utils.*` and `my_project.*` by top-level name.
+ENV PYTHONPATH=/repo/my-project
+
+# Ultralytics is NOT installed: my-project/tests/conftest.py stubs it, and the
+# pipeline package imports it lazily inside the two functions that score a
+# checkpoint. Installing it would add ~2 GB for code these tests never reach.
+CMD ["pytest", "my-project/tests", "pipeline/tests", "-q"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ python -m pipeline.compare --last 10              # runs you already have
 **Full instructions, costs, troubleshooting and how to read the numbers:
 [`docs/RUNBOOK.md`](docs/RUNBOOK.md).**
 
+Or without installing anything, on any machine with Docker — the checks only, since
+the container has no GPU and no data:
+
+```bash
+docker build -t federated-yolov8:cpu .
+docker run --rm federated-yolov8:cpu        # 148 passed, 1 skipped
+```
+
 **Latest measured result.** 6 vehicles × 1 400 images, condition-partitioned, 6 rounds
 × 4 local epochs on an RTX 5070 Ti, scored on 1 000 images no vehicle trained on:
 


### PR DESCRIPTION
> **Stacked on #37.** It has to be: on the pre-#37 tree this image reports 3 failures. Review #37 first.

## What was wrong or missing

A fresh clone of this repo costs about an hour. The venv has to be python.org and not conda, torch has to match the card, `flwr` has to be stopped from building its own runtime environment — and every one of those failures is quiet. None of it is necessary just to run the tests, and running the tests somewhere other than this laptop is exactly what was never happening.

That mattered more than tidiness: running the suite in a place that has never been used is what found the three tests fixed in #37.

## What changed

`Dockerfile` and `.dockerignore`.

```
docker build -t federated-yolov8:cpu .
docker run --rm federated-yolov8:cpu
```

It **mirrors CI's install steps deliberately** rather than inventing its own: if the two drift, a green container stops meaning a green CI.

**What it is not**, said in the file rather than discovered later:

- it cannot train — CPU torch, no GPU passthrough. Real runs need a Blackwell card and cu128.
- it has no data — BDD100K is 7.6 GB in a kagglehub cache, and the first hard rule here is that data is never committed.
- it is not a deployment — Flower's SuperLink/SuperNode setup is a different exercise and is already configured in `pyproject.toml`.

`.dockerignore` is written as a **safety rule, not an optimisation**: the build context is the one place the never-commit-data rule can be bypassed without touching git. `docs/` and `.github/` are deliberately *kept* — tests assert against them, and excluding them made the suite fail inside the image and pass outside it, which is the worst of both.

## How it was verified

```
$ docker run --rm federated-yolov8:cpu
148 passed, 1 skipped, 2 warnings in 2.52s
```

The 1 skipped is `test_generated_paths_are_all_gitignored`, which correctly skips where there is no `.git`.

Checked **inside the container** rather than inferred from `.dockerignore`:

```
$ docker run --rm federated-yolov8:cpu bash -lc '...'
jpgs: 0
pt files: 0
repo size: 294M
image size: 2.05GB
```

## Checklist

- [ ] A test fails without this change — n/a, no source changed
- [x] Full suite green, inside the image and outside it
- [ ] CI green, including the federation smoke — not yet run on this branch
- [x] Docs updated in this PR (`README.md`, and the Dockerfile header is the doc)
- [x] No data, checkpoints, reports or credentials staged — asserted inside the image
- [x] `my-project/pyproject.toml` not committed in its flwr-rewritten form
- [ ] `STATUS.md` — item 1b is already covered by #37

## Still open

- **The image is not built in CI.** So it can rot: a change to CI's install steps will not break anything here until someone runs `docker build` by hand. Adding a build job is small and is the obvious follow-up — it was left out to keep this PR to one thing.
- **The federation smoke does not run in the container.** It needs the `laptop_copy` fixture branch fetched at build time, which would put a git dependency into an image that deliberately has no `.git`. CI still covers it.
- 291 MB of the image is `my-project/batch/*/labels` — real committed repo content, not smuggled data. Trimming it would mean first establishing which tests read a real shard layout, and 291 MB of a 2 GB image is not worth finding that out wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)