### PR TITLE
perf(profile): measure where a round's seconds go, and cut a lever that cannot pay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Open the one file that owns the thing. Do not read the package to find it.
 | A path, or an env var a subprocess needs | `pipeline/paths.py` — nowhere else |
 | Shard assignment, conditions, partitioning, quantity skew | `pipeline/vehicles.py` |
 | What a log line means | `pipeline/logparse.py` |
+| Where a round's seconds went | `pipeline/profile.py` |
 | The four pass criteria | `pipeline/verify.py` |
 | The shared holdout, and scoring the global model on it | `pipeline/holdout.py` |
 | The centralised baseline, and the gap to it | `pipeline/baseline.py` |

--- a/docs/PHASED_PLAN.md
+++ b/docs/PHASED_PLAN.md
@@ -21,7 +21,7 @@ result is a result.
 
 | Phase | Question it answers | Gate to the next phase |
 |---|---|---|
-| **0 — Measure** | Where does the 73 % of non-training wall clock go? | a per-round timing breakdown exists on disk |
+| **0 — Measure** ✅ | Where does the 73 % of non-training wall clock go? | **answered: it does not leave training.** 85.3 % train, 13.8 % evaluate, 0.6 % idle, clients never overlapping |
 | **1 — Runtime** | How many runs per GPU-hour? | wall clock per image-visit down ≥ 2×, holdout mAP unchanged within noise |
 | **2 — Schedule & head** | Why do 24 effective epochs only reach 0.4173? | box/cls/dfl fall *within* a round instead of rising |
 | **3 — Evidence** | Is any difference real? | the seed spread is known and printed beside every comparison |
@@ -35,19 +35,44 @@ badly-scheduled trainer measures the trainer.
 
 ---
 
-## Phase 0 — measure the round before optimising it
+## Phase 0 — measure the round before optimising it — **done**
 
-Backlog 95. One run of the demo profile, instrumented, producing a table of where the
-seconds go: shard scan, model construction, AMP check, warmup, steady-state training,
-validation, checkpoint write, weight serialisation, server aggregation, idle.
+Backlog 95. `pipeline/profile.py` pairs markers the logs already carry into per-phase
+intervals, so the 3 296 s reference run could be profiled after the fact rather than
+re-run:
 
-**Why it comes first.** The 27 % utilisation figure is a mean over the whole run. It
-does not distinguish "the dataloader starves the GPU" from "clients are serialised and
-five of them are waiting". Those two have completely different fixes and the plan below
-assumes the first — an assumption worth 20 minutes to check.
+```bash
+python -m pipeline.profile --server-log my-project/logs/server.30716.log --json
+```
 
-Deliverable: `pipeline/profile.py` and a stored breakdown per stage. Nothing else in
-phase 1 should be believed until this exists.
+| phase | seconds | share of wall |
+|---|---|---|
+| **train** | 2 784.1 | **85.3 %** |
+| **evaluate** | 450.7 | **13.8 %** |
+| construct (model load) | 8.6 | 0.3 % |
+| aggregate + checkpoint | 1.7 | 0.05 % |
+| weights in + out | 0.6 | 0.02 % |
+| unaccounted (Ray, teardown, idle) | 19.9 | 0.6 % |
+
+72 client episodes, **never more than one overlapping**. Wall clock 3 266 s.
+
+**Both worlds are real, and the measurement separates them.**
+
+- Clients *are* serialised — `max_concurrent = 1` across 72 episodes. Lever 1 is
+  available in full, and it is mathematically a no-op.
+- Orchestration is *not* where the time goes — 99.1 % of the wall clock is inside a
+  client doing work, and the GPU still averaged 27 % while it did. The idle is inside
+  `train()`, which is the data path, which is levers 2–3.
+
+**What this deletes from phase 1.** Model construction totals 8.6 s across 72 episodes.
+Persistent client actors (lever 5) and anything else that removes per-round fixed cost
+is capped at **0.3 %** of the run. It was ranked "small, but free"; it is small enough
+not to be worth the state-handling. Cut.
+
+**What it adds.** `evaluate` is 13.8 % — six clients re-scoring their own val split
+every round, for a number `docs/PHASED_PLAN.md` already calls the flattering one. The
+holdout is what the project reports. Evaluating every client every round is 450 s of
+GPU time spent on a metric that is not the headline.
 
 ---
 
@@ -63,7 +88,8 @@ expected effect on this hardware.
 | 2 | **`cache="ram"`** in the client's `train()` | `client_app.py` ⚠ | 1 400 images at 640 px is ~2–3 GB of RAM. Removes JPEG decode from the step loop — the prime suspect for 27 % utilisation | 1.3–2× per client |
 | 3 | **Windows dataloader** — `workers=0` today | `client_app.py` ⚠ | the comment is right that spawned workers deadlock inside a Ray actor, but `workers=0` means decode happens on the training thread. With `cache="ram"` this stops mattering; without it, it *is* the bottleneck | see 2 |
 | 4 | **Reuse the label cache across rounds** | `pipeline/build_fleet.py`, shard dirs | Ultralytics writes `labels.cache` beside each shard and rescans when it is missing. 6 vehicles × 6 rounds = 36 scans. The cache survives only if the fleet is not rebuilt between rounds — assert that, do not assume it | seconds × 36 |
-| 5 | **Persistent client actors** | Flower client state ⚠ | today the `YOLO` object is constructed from yaml and reloaded every round. Keeping it in node state removes a fixed per-round cost | small, but free |
+| ~~5~~ | ~~**Persistent client actors**~~ | — | **Cut by phase 0.** Model construction is 8.6 s across 72 episodes, 0.3 % of the run. A perfect fix here buys three seconds per round | measured, not worth it |
+| 6 | **Evaluate fewer clients per round** | `my-project/pyproject.toml` ⚠ | phase 0 found `evaluate` at **13.8 %** of wall clock, spent on the self-reported metric the project already calls flattering. `fraction_evaluate < 1.0`, or evaluate only on the final round | up to 1.16× |
 
 **The trap this phase must not fall into.** Every one of these can make a run finish
 faster *and* train less. Lever 1 changes nothing mathematically — clients are

--- a/docs/prompts/2026-08-16-phase0-round-profile.md
+++ b/docs/prompts/2026-08-16-phase0-round-profile.md
@@ -1,0 +1,88 @@
+# Phase 0 — measure the round before optimising it
+
+**Date:** 2026-08-16 · **Phase:** 0 of [`docs/PHASED_PLAN.md`](../PHASED_PLAN.md) ·
+**Backlog:** 95
+
+## Goal
+
+Answer one question with a number rather than a guess: **where does the 73 % of
+non-training wall clock go?**
+
+The reference run held the GPU at 27 % mean utilisation. That mean is compatible with
+two completely different worlds, and they have opposite fixes:
+
+| World | Signature | Fix |
+|---|---|---|
+| Clients are serialised and five of six wait | client-busy time ≈ wall clock, but only one client busy at a time | `num-gpus = 0.33` (phase 1, lever 1) |
+| The dataloader starves the GPU inside `train()` | almost all wall clock *is* inside `train()`, and the card still idles | `cache="ram"`, workers (phase 1, levers 2–3) |
+
+Phase 1's plan assumes the second. That assumption is worth twenty minutes to check,
+and phase 1 must not be believed until it is checked.
+
+## Hard constraints
+
+- **`pipeline/` must not modify `my-project/`.** The profiler reads log lines that are
+  *already emitted*, exactly as `logparse.py` does. No new logging on the other side of
+  the boundary, no instrumentation commit smuggled in.
+- **No new dependency.** `datetime.strptime` over lines this repo already writes.
+- **A run this project has already done must be profilable.** The deliverable is
+  useless if it needs a fresh instrumented run to say anything — the 3 296 s reference
+  run is on disk and it is the run whose 27 % started this.
+- **No estimate presented as a measurement.** Anything the timestamps do not support
+  (per-epoch warmup vs steady-state, JPEG decode as a share of the step) is reported as
+  unaccounted, not modelled.
+
+## Inputs — the markers already in the logs
+
+Verified against `my-project/logs/client.45544.log` and `server.30716.log` from the
+six-round run of 2026-08-06:
+
+```
+00:57:35,355 [Client] Creating FlowerClient instance from client_fn.
+00:57:35,513 [Client] YOLO model loaded successfully.
+00:57:35,530 [Client] Received weights with checksum: 705.23
+00:57:35,539 [Client] Successfully applied received weights to model
+00:57:35,545 [Client] Starting local training with batch_id=8, local_epochs=4
+00:58:55,185 [Client] 8 Training done. metrics={...}
+00:58:55,190 [Client] Sending back weights with checksum: 236.48
+...
+01:05:16,263 [Server] Aggregating 6 fit results and 0 failures
+01:05:16,408 [Server] Aggregated parameters with checksum: 159.89
+01:05:16,671 [Server] Saved global checkpoint: checkpoints\global_round_1.pt
+```
+
+Every phase boundary phase 0 needs is a pair of those, timestamped to the millisecond.
+
+## Deliverables
+
+| # | File | What it does |
+|---|---|---|
+| 1 | `pipeline/profile.py` | pairs the markers into intervals, sums seconds per phase, prints a table with each phase's share of the wall clock, and writes `pipeline/.state/profile-<stamp>.json` |
+| 2 | the verdict line | the profiler itself names which of the two worlds the run was in, from `train_share` and `max_concurrent_clients` — not left to the reader |
+| 3 | `pipeline/tests/test_profile.py` | a test named for the failure it catches, against captured real lines |
+
+## The two numbers that decide phase 1
+
+- **`train_share`** — seconds inside `Starting local training … Training done`, over
+  wall clock. High means the overhead is *inside* training and levers 2–3 are the ones
+  that matter.
+- **`max_concurrent_clients`** — the most client episodes overlapping at any instant.
+  `1` proves serialisation and makes lever 1 the whole result, whatever `train_share`
+  says.
+
+Both are reported; neither is inferred from the other.
+
+## Definition of done
+
+```bash
+python -m pytest pipeline/tests -q          # exit 0
+python -m pipeline.profile                  # prints the breakdown of the last run
+python -m pipeline.profile --json           # writes .state/profile-<stamp>.json
+```
+
+The commit body carries the table for the 2026-08-06 reference run, and the verdict.
+
+## Out of scope
+
+Changing anything the profiler measures. Phase 0 ships a measurement and no lever; a
+commit that does both is a commit whose lever cannot be attributed.

--- a/pipeline/docs_index.py
+++ b/pipeline/docs_index.py
@@ -130,6 +130,14 @@ ROLES: dict[str, dict] = {
                        "run's cost is measured rather than estimated.",
         "tab": "Live, Plan",
     },
+    "profile": {
+        "command": "python -m pipeline.profile --json",
+        "contributes": "Where a round's seconds went, from the timestamps already in "
+                       "the logs. A mean utilisation figure cannot distinguish "
+                       "serialised clients from a starved dataloader; the overlap "
+                       "count and the share spent inside train() can.",
+        "tab": "—",
+    },
     "paths": {
         "command": "—",
         "contributes": "One place that knows the layout and the environment every "

--- a/pipeline/profile.py
+++ b/pipeline/profile.py
@@ -1,0 +1,279 @@
+"""Where the seconds of a round actually went.
+
+Phase 0 of the plan exists because "27 % mean GPU utilisation" is compatible with two
+different worlds that have opposite fixes: clients serialised on one card, or a
+dataloader starving the GPU inside ``train()``. The mean cannot tell them apart. The
+timestamps can, and they are already in the logs.
+
+Nothing here adds logging to my-project. Every boundary below is a pair of lines this
+project has written since before the profiler existed, which is why the 3 296 s
+reference run of 2026-08-06 can be profiled after the fact rather than re-run.
+
+Two numbers decide phase 1, and they are measured separately rather than one inferred
+from the other:
+
+* ``train_share``  -- wall clock spent inside train(), over wall clock. High means the
+  overhead is *inside* training, so the levers are cache and dataloader workers.
+* ``max_concurrent`` -- the most client episodes overlapping at any instant. 1 proves
+  serialisation, whatever train_share says, and makes num-gpus the whole result.
+
+    python -m pipeline.profile
+    python -m pipeline.profile --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from . import logparse, paths
+
+TS = re.compile(r"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d{3}) - \w+ - \[(\w+)\] (.*)$")
+
+# marker substring -> (phase, "open" | "close"). One line can drive two phases: the
+# line that ends training is the same line that starts serialising the result, so
+# every entry is tested rather than stopping at the first hit.
+CLIENT_MARKERS = [
+    ("Creating FlowerClient instance", "construct", "open"),
+    ("YOLO model loaded successfully", "construct", "close"),
+    ("Received weights with checksum", "weights_in", "open"),
+    ("Received evaluation weights with checksum", "weights_in", "open"),
+    ("Successfully applied received weights", "weights_in", "close"),
+    ("Setting evaluation weights", "weights_in", "close"),
+    ("Starting local training with batch_id", "train", "open"),
+    ("Training done", "train", "close"),
+    ("Training done", "weights_out", "open"),
+    ("Sending back weights with checksum", "weights_out", "close"),
+    ("Starting evaluation with batch_id", "evaluate", "open"),
+    ("Evaluation done", "evaluate", "close"),
+]
+
+SERVER_MARKERS = [
+    ("Aggregating", "aggregate", "open"),
+    ("Aggregated parameters with checksum", "aggregate", "close"),
+    ("Aggregated parameters with checksum", "checkpoint", "open"),
+    ("Saved global checkpoint", "checkpoint", "close"),
+]
+
+# An episode is one client's turn on the card: constructed, given weights, trained or
+# evaluated, handed back. Overlapping episodes are what concurrency means here.
+EPISODE_OPEN = "Creating FlowerClient instance"
+EPISODE_CLOSE = ("Sending back weights with checksum", "Evaluation done")
+
+PHASES = ["construct", "weights_in", "train", "weights_out", "evaluate",
+          "aggregate", "checkpoint"]
+
+
+def _parse_ts(s: str) -> float:
+    return datetime.strptime(s, "%Y-%m-%d %H:%M:%S,%f").timestamp()
+
+
+def intervals(text: str, markers: list[tuple[str, str, str]]) -> dict[str, list[tuple[float, float]]]:
+    """Pair open/close markers into [start, end) intervals per phase.
+
+    A phase reopened before it closed keeps the *later* open: a client that crashed
+    mid-round leaves a dangling marker, and carrying the stale one forward would
+    attribute the crash gap to whatever phase happened to be open.
+    """
+    out: dict[str, list[tuple[float, float]]] = {p: [] for p in PHASES}
+    open_at: dict[str, float] = {}
+    for line in text.splitlines():
+        m = TS.match(line)
+        if not m:
+            continue
+        t, body = _parse_ts(m.group(1)), m.group(3)
+        for needle, phase, side in markers:
+            if needle not in body:
+                continue
+            if side == "open":
+                open_at[phase] = t
+            elif (start := open_at.pop(phase, None)) is not None:
+                out[phase].append((start, t))
+    return out
+
+
+def episodes(text: str) -> list[tuple[float, float]]:
+    """One client's turn on the card, start to hand-back."""
+    out, start = [], None
+    for line in text.splitlines():
+        m = TS.match(line)
+        if not m or m.group(2) != "Client":
+            continue
+        t, body = _parse_ts(m.group(1)), m.group(3)
+        if EPISODE_OPEN in body:
+            start = t
+        elif start is not None and any(c in body for c in EPISODE_CLOSE):
+            out.append((start, t))
+            start = None
+    return out
+
+
+def union_seconds(spans: list[tuple[float, float]]) -> float:
+    """Wall clock covered by at least one span. Not the sum: spans can overlap."""
+    total, end = 0.0, None
+    for s, e in sorted(spans):
+        if end is None or s > end:
+            total += e - s
+            end = e
+        elif e > end:
+            total += e - end
+            end = e
+    return total
+
+
+def max_overlap(spans: list[tuple[float, float]]) -> int:
+    """Most spans open at once. 1 means serialised."""
+    events = sorted([(s, 1) for s, _ in spans] + [(e, -1) for _, e in spans])
+    best = cur = 0
+    for _, d in events:
+        cur += d
+        best = max(best, cur)
+    return best
+
+
+def profile(server_log: Path | None = None, log_dir: Path | None = None) -> dict:
+    """Per-phase seconds for one run, from the logs it already wrote."""
+    server = server_log or logparse.latest_run_log(log_dir)
+    if server is None:
+        return {"error": "no server log that aggregated a round -- has a federation run?"}
+
+    # Client logs of *this* run only. Logs are named per process and accumulate, so
+    # reading the directory would mix six runs into one breakdown. The window is
+    # bounded at *both* ends: `--server-log` profiles a past run, and a lower bound
+    # alone would sweep in every client log written since.
+    st = server.stat()
+    lo, hi = min(st.st_ctime, st.st_mtime) - 60, st.st_mtime + 60
+    clients = [f for f in logparse.iter_logs("client*.log", log_dir)
+               if f.is_file() and lo <= f.stat().st_mtime <= hi]
+
+    spans: dict[str, list[tuple[float, float]]] = {p: [] for p in PHASES}
+    eps: list[tuple[float, float]] = []
+    stamps: list[float] = []
+
+    for f in clients:
+        text = f.read_text(errors="replace")
+        for phase, got in intervals(text, CLIENT_MARKERS).items():
+            spans[phase] += got
+        eps += episodes(text)
+        stamps += [_parse_ts(m.group(1)) for m in map(TS.match, text.splitlines()) if m]
+
+    server_text = server.read_text(errors="replace")
+    for phase, got in intervals(server_text, SERVER_MARKERS).items():
+        spans[phase] += got
+    stamps += [_parse_ts(m.group(1)) for m in map(TS.match, server_text.splitlines()) if m]
+
+    if not stamps:
+        return {"error": f"no timestamped lines in {server.name} or its client logs"}
+
+    wall = max(stamps) - min(stamps)
+    busy = union_seconds(eps)
+    breakdown = {p: round(union_seconds(spans[p]), 1) for p in PHASES}
+    train_share = breakdown["train"] / wall if wall else 0.0
+
+    return {
+        "server_log": str(server),
+        "client_logs": [str(c) for c in clients],
+        "wall_s": round(wall, 1),
+        "phases": breakdown,
+        # Union, so this is honest whether or not episodes overlap. Whatever is left is
+        # Ray scheduling, process teardown and genuine idle -- named as unaccounted
+        # rather than modelled, because the timestamps do not say which.
+        "unaccounted_s": round(wall - busy, 1),
+        "episodes": len(eps),
+        "max_concurrent": max_overlap(eps),
+        "train_share": round(train_share, 3),
+    }
+
+
+def verdict(p: dict) -> list[str]:
+    """Which of the two worlds the run was in. Both checks, independently."""
+    out = []
+    if p["max_concurrent"] <= 1 and p["episodes"] > 1:
+        out.append(f"[SERIALISED] {p['episodes']} client episodes, never more than "
+                   f"{p['max_concurrent']} at a time -- one client owns the card. "
+                   f"num-gpus < 1.0 is the lever, and it is a no-op mathematically.")
+    else:
+        out.append(f"[CONCURRENT] up to {p['max_concurrent']} client episodes overlap; "
+                   f"packing more clients will not be the whole win.")
+    if p["train_share"] >= 0.85:
+        out.append(f"[IN-TRAINING] {p['train_share']:.0%} of the wall clock is inside "
+                   f"train(). The overhead is the data path, not orchestration: "
+                   f"cache and dataloader workers are the levers.")
+    else:
+        out.append(f"[AROUND-TRAINING] only {p['train_share']:.0%} of the wall clock is "
+                   f"inside train(); {100 * (1 - p['train_share']):.0f}% is setup, "
+                   f"aggregation and idle. Fix that before touching the data path.")
+    return out
+
+
+def render(p: dict) -> str:
+    if "error" in p:
+        return f"profile: {p['error']}"
+    wall = p["wall_s"]
+    lines = [f"{Path(p['server_log']).name} -- {len(p['client_logs'])} client log(s), "
+             f"{p['episodes']} episodes, wall {wall:.0f}s",
+             "",
+             f"{'phase':<14}{'seconds':>10}{'share':>9}"]
+    for phase, secs in p["phases"].items():
+        lines.append(f"{phase:<14}{secs:>10.1f}{secs / wall if wall else 0:>9.1%}")
+    lines.append(f"{'unaccounted':<14}{p['unaccounted_s']:>10.1f}"
+                 f"{p['unaccounted_s'] / wall if wall else 0:>9.1%}")
+    return "\n".join(lines + [""] + verdict(p))
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--server-log", type=Path, help="profile this run instead of the last one")
+    ap.add_argument("--json", action="store_true", help="also write .state/profile-<stamp>.json")
+    a = ap.parse_args(argv)
+
+    p = profile(a.server_log)
+    print(render(p))
+    if "error" in p:
+        return 1
+    if a.json:
+        paths.STATE.mkdir(parents=True, exist_ok=True)
+        stamp = Path(p["server_log"]).stem.replace("server.", "")
+        out = paths.STATE / f"profile-{stamp}.json"
+        out.write_text(json.dumps(p, indent=2))
+        print(f"\nwrote {out}")
+    return 0
+
+
+def demo() -> None:
+    """Self-check: a hand-computable two-episode run."""
+    text = "\n".join([
+        "2026-08-06 00:00:00,000 - INFO - [Client] Creating FlowerClient instance from client_fn.",
+        "2026-08-06 00:00:01,000 - INFO - [Client] YOLO model loaded successfully.",
+        "2026-08-06 00:00:01,000 - INFO - [Client] Received weights with checksum: 1.0",
+        "2026-08-06 00:00:02,000 - INFO - [Client] Successfully applied received weights to model",
+        "2026-08-06 00:00:02,000 - INFO - [Client] Starting local training with batch_id=1, local_epochs=4",
+        "2026-08-06 00:00:12,000 - INFO - [Client] 1 Training done. metrics={}",
+        "2026-08-06 00:00:13,000 - INFO - [Client] Sending back weights with checksum: 2.0",
+        "2026-08-06 00:00:20,000 - INFO - [Client] Creating FlowerClient instance from client_fn.",
+        "2026-08-06 00:00:20,000 - INFO - [Client] YOLO model loaded successfully.",
+        "2026-08-06 00:00:20,000 - INFO - [Client] Starting evaluation with batch_id=1",
+        "2026-08-06 00:00:25,000 - INFO - [Client] Evaluation done. Loss=0.1, metrics={}",
+    ])
+    got = intervals(text, CLIENT_MARKERS)
+    assert union_seconds(got["train"]) == 10.0, got["train"]
+    assert union_seconds(got["construct"]) == 1.0, got["construct"]
+    assert union_seconds(got["weights_out"]) == 1.0, got["weights_out"]
+    assert union_seconds(got["evaluate"]) == 5.0, got["evaluate"]
+
+    eps = episodes(text)
+    assert len(eps) == 2 and max_overlap(eps) == 1, eps
+    # Two episodes, 13 s and 5 s, with a 7 s gap: 25 s wall, 18 s busy.
+    assert union_seconds(eps) == 18.0, eps
+
+    # Overlap is counted, not assumed away.
+    assert max_overlap([(0.0, 10.0), (5.0, 15.0), (20.0, 30.0)]) == 2
+    assert union_seconds([(0.0, 10.0), (5.0, 15.0)]) == 15.0
+    print("profile self-check OK")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -1729,3 +1729,82 @@ def test_with_no_real_run_at_all_the_checksums_are_empty_not_wrong(tmp_path):
     assert logparse.latest_run_log(tmp_path) is None
     assert logparse.aggregate_checksums(tmp_path) == []
     assert logparse.federation_learned(tmp_path)[0] is False
+
+
+# ------------------------------------------------------------- the round profile
+from pipeline import profile as _profile  # noqa: E402
+
+# Two client episodes from the real six-round run, trimmed. The line that ends
+# training is the same line that starts serialising the result.
+PROFILE_LINES = "\n".join([
+    "2026-08-06 00:57:35,355 - INFO - [Client] Creating FlowerClient instance from client_fn.",
+    "2026-08-06 00:57:35,513 - INFO - [Client] YOLO model loaded successfully.",
+    "2026-08-06 00:57:35,530 - INFO - [Client] Received weights with checksum: 705.23",
+    "2026-08-06 00:57:35,539 - INFO - [Client] Successfully applied received weights to model",
+    "2026-08-06 00:57:35,545 - INFO - [Client] Starting local training with batch_id=8, local_epochs=4",
+    "2026-08-06 00:58:55,185 - INFO - [Client] 8 Training done. metrics={'mAP50': 0.35}",
+    "2026-08-06 00:58:55,190 - INFO - [Client] Sending back weights with checksum: 236.48",
+    "2026-08-06 00:58:55,338 - INFO - [Client] Creating FlowerClient instance from client_fn.",
+    "2026-08-06 00:58:55,436 - INFO - [Client] YOLO model loaded successfully.",
+    "2026-08-06 00:58:55,464 - INFO - [Client] Starting local training with batch_id=2, local_epochs=4",
+    "2026-08-06 01:00:08,898 - INFO - [Client] 2 Training done. metrics={'mAP50': 0.33}",
+    "2026-08-06 01:00:08,904 - INFO - [Client] Sending back weights with checksum: 205.59",
+])
+
+
+def test_the_phase_after_training_is_measured_rather_than_left_at_zero():
+    """`Training done` closes training *and* opens serialisation. Stopping at the
+    first marker a line matches reported weights_out as 0.0 s for every run --
+    a phase that looks free because it was never measured, not because it is."""
+    got = _profile.intervals(PROFILE_LINES, _profile.CLIENT_MARKERS)
+    assert _profile.union_seconds(got["train"]) == pytest.approx(79.64 + 73.434, abs=0.01)
+    assert _profile.union_seconds(got["weights_out"]) == pytest.approx(0.011, abs=0.001)
+    assert _profile.union_seconds(got["construct"]) == pytest.approx(0.158 + 0.098, abs=0.001)
+
+
+def test_serialised_clients_are_reported_as_serialised_not_averaged_away():
+    """27 % mean utilisation is compatible with six clients each at 27 % and with one
+    client at 27 % while five wait. Only the overlap count tells them apart, and the
+    fix differs: `num-gpus < 1.0` for the second, the data path for the first."""
+    eps = _profile.episodes(PROFILE_LINES)
+    assert len(eps) == 2
+    assert _profile.max_overlap(eps) == 1, "these two episodes are back to back, not concurrent"
+    assert _profile.max_overlap([(0.0, 10.0), (5.0, 15.0), (5.5, 6.0)]) == 3
+
+
+def test_a_past_run_is_profiled_from_its_own_client_logs_not_every_later_one(tmp_path):
+    """`--server-log` profiles a run that is over. A lower time bound alone -- which
+    is all the current-run helpers need -- would sweep in every client log written
+    since, and charge this run with the next six runs' training seconds."""
+    import os
+    import time
+
+    now = time.time()
+    server = tmp_path / "server.10.log"
+    server.write_text("2026-08-06 00:57:26,281 - INFO - [Server] Aggregating 6 fit results\n"
+                      "2026-08-06 01:05:16,408 - INFO - [Server] Aggregated parameters with checksum: 159.9\n")
+    os.utime(server, (now - 7200, now - 7200))
+
+    mine = tmp_path / "client.11.log"
+    mine.write_text(PROFILE_LINES)
+    os.utime(mine, (now - 7200, now - 7200))
+
+    later = tmp_path / "client.12.log"          # a run that happened afterwards
+    later.write_text(PROFILE_LINES)
+
+    p = _profile.profile(server_log=server, log_dir=tmp_path)
+    assert [Path(c).name for c in p["client_logs"]] == ["client.11.log"]
+    assert p["episodes"] == 2, "the later run's episodes are not this run's"
+    assert p["max_concurrent"] == 1
+
+
+def test_the_profiler_says_which_lever_the_measurement_points_at():
+    """Phase 0 exists to choose between two fixes. A breakdown that leaves the
+    choice to the reader has not made it."""
+    serial_in_training = {"episodes": 6, "max_concurrent": 1, "train_share": 0.85}
+    lines = " ".join(_profile.verdict(serial_in_training))
+    assert "SERIALISED" in lines and "IN-TRAINING" in lines
+
+    concurrent_overhead = {"episodes": 6, "max_concurrent": 3, "train_share": 0.40}
+    lines = " ".join(_profile.verdict(concurrent_overhead))
+    assert "CONCURRENT" in lines and "AROUND-TRAINING" in lines


### PR DESCRIPTION
## What was wrong or missing

Phase 0 of `docs/PHASED_PLAN.md`. "27 % mean GPU utilisation" is compatible with two worlds that have **opposite** fixes:

| World | Fix |
|---|---|
| clients serialised, five of six waiting | `num-gpus < 1.0` |
| the dataloader starves the GPU inside `train()` | `cache`, dataloader workers |

A mean cannot tell them apart, and phase 1 was planned assuming the second.

## What changed

`pipeline/profile.py` pairs markers the logs **already** carry into per-phase intervals. Nothing was added to `my-project/` — which is why the 3 296 s reference run of 2026-08-06 could be profiled after the fact instead of re-run.

```
$ python -m pipeline.profile --server-log my-project/logs/server.30716.log --json

phase            seconds    share
train             2784.1    85.3%
evaluate           450.7    13.8%
construct            8.6     0.3%
aggregate            0.9     0.0%
checkpoint           0.8     0.0%
weights in+out       0.6     0.0%
unaccounted         19.9     0.6%

72 episodes, wall 3266s, max_concurrent 1
```

**Both worlds are real, and now separated.** Clients *are* serialised — 72 episodes, never two at once. But orchestration is *not* the overhead: 99.1 % of wall clock is a client doing work, and the card still averaged 27 % while it did.

Two consequences for the plan, in this PR:

- **Persistent client actors (phase 1 lever 5) is cut.** Model construction totals 8.6 s across 72 episodes — a perfect fix buys three seconds per round. It was ranked "small, but free" on a guess.
- **`evaluate` is 13.8 %** of the run, spent every round on the self-scored metric this project already calls flattering. Added as a lever.

`train_share` and `max_concurrent` are measured independently rather than one inferred from the other. A run can be in both worlds; this one is.

**Found while writing it:** `Training done` is the line that ends training *and* starts serialising the result. Stopping at the first marker a line matched reported `weights_out` as 0.0 s for every run — a phase that looks free because it was never measured. Caught by the module's own self-check before it reached a table.

## How it was verified

```
$ python -m pytest my-project/tests pipeline/tests -q
165 passed in 2.73s
```

Up from 161. Four new tests, each named for the failure it catches — including the `weights_out` bug above, and the two-sided log window that stops `--server-log` charging a past run with every later run's client logs.

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke
- [x] Docs updated in this PR (`docs/PHASED_PLAN.md`, `CLAUDE.md`, `pipeline/docs_index.py`, prompt in `docs/prompts/`)
- [x] No data, checkpoints, reports or credentials staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)