### PR TITLE
fix(server): refuse a run without adopting the config it asked for

### DIFF
--- a/pipeline/server.py
+++ b/pipeline/server.py
@@ -363,7 +363,11 @@ class Handler(BaseHTTPRequestHandler):
 
         if self.path == "/api/run":
             global CONFIG
-            CONFIG = Config(
+            # Built locally and only adopted once every check has passed. Assigning
+            # first meant a rejected request still replaced the config the stage table
+            # previews, so /api/plan then described a run the server had refused to
+            # start -- and the next valid POST hid it by overwriting.
+            cfg = Config(
                 profile=body.get("profile", "demo"),
                 n_vehicles=int(body.get("vehicles", 6)),
                 rounds=int(body.get("rounds", 2)),
@@ -376,23 +380,24 @@ class Handler(BaseHTTPRequestHandler):
                 proximal_mu=float(body.get("proximal_mu", 0.0) or 0.0),
                 ray_address=body.get("ray_address") or None,
             )
-            if CONFIG.strategy not in stages.STRATEGIES:
-                return self._json({"error": f"unknown strategy {CONFIG.strategy!r}; "
+            if cfg.strategy not in stages.STRATEGIES:
+                return self._json({"error": f"unknown strategy {cfg.strategy!r}; "
                                             f"known: {', '.join(stages.STRATEGIES)}"}, 400)
-            if CONFIG.partition not in vehicles.PARTITIONS:
+            if cfg.partition not in vehicles.PARTITIONS:
                 # Rejected here rather than three subprocesses later, where it would
                 # surface as a stage failure with the real cause buried in a log.
-                return self._json({"error": f"unknown partition {CONFIG.partition!r}; "
+                return self._json({"error": f"unknown partition {cfg.partition!r}; "
                                             f"known: {', '.join(vehicles.PARTITIONS)}"}, 400)
-            if CONFIG.size_skew < 0:
+            if cfg.size_skew < 0:
                 # Same reason: caught here, not as a ValueError inside build_fleet's
                 # subprocess three stages later.
                 return self._json({"error": "size_skew must be >= 0, "
-                                            f"got {CONFIG.size_skew}"}, 400)
+                                            f"got {cfg.size_skew}"}, 400)
             try:
                 chain = stages.resolve(body.get("stages"), body.get("skip"))
             except SystemExit as e:
                 return self._json({"error": str(e)}, 400)
+            CONFIG = cfg
             started = STATE.start(CONFIG, chain, bool(body.get("confirm")),
                                   body.get("ray_address") or None)
             return self._json({"started": started, "busy": STATE.busy},

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -1731,6 +1731,30 @@ def test_with_no_real_run_at_all_the_checksums_are_empty_not_wrong(tmp_path):
     assert logparse.federation_learned(tmp_path)[0] is False
 
 
+def test_a_refused_run_does_not_become_the_config_the_plan_previews():
+    """/api/run validated the config it had already adopted, so a POST the server
+    refused with a 400 still replaced the global one -- and /api/plan then previewed
+    the stage table for a run that was never allowed to start. Harmless-looking
+    because the next valid POST overwrote it, which is what kept it in the code."""
+    import io
+
+    from pipeline import server as srv
+
+    before = srv.CONFIG
+    handler = object.__new__(srv.Handler)          # do_POST needs no socket
+    handler.path = "/api/run"
+    body = json.dumps({"partition": "no-such-partition", "vehicles": 99}).encode()
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = io.BytesIO(body)
+    seen = {}
+    handler._json = lambda payload, code=200: seen.update(payload=payload, code=code)
+
+    handler.do_POST()
+
+    assert seen["code"] == 400 and "no-such-partition" in seen["payload"]["error"]
+    assert srv.CONFIG is before, "a refused run must not replace the previewed config"
+
+
 # ------------------------------------------------------------- the round profile
 from pipeline import profile as _profile  # noqa: E402
 


### PR DESCRIPTION
## What was wrong or missing

`/api/run` assigned the global `CONFIG` and validated it **afterwards**, so a request the server answered with `400` still replaced the config the stage table previews. `GET /api/plan` then described a run that was never allowed to start.

It has always done this — the strategy and partition guards predate the size-skew one — and it stayed invisible because the next valid POST overwrote the bad value. Filed rather than fixed while building `--size-skew`; own branch, as recorded in `STATUS.md`.

## What changed

The config is built locally and adopted only once **every** check has passed — including `stages.resolve()`, which was the fourth way out of the handler that left the global already replaced.

Deliberately not changed: the validation rules themselves, and the response codes.

## How it was verified

```
$ python -m pytest my-project/tests pipeline/tests -q
166 passed in 1.92s
```

The new test drives `do_POST` with a stubbed `rfile`/`_json` — no socket — and fails when only `pipeline/server.py` is reverted:

```
$ git stash push pipeline/server.py && python -m pytest pipeline/tests -q -k refused
E       AssertionError: a refused run must not replace the previewed config
1 failed, 2 passed
```

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke
- [x] Docs updated in this PR (the `STATUS.md` entry that filed it is now resolved by PR #52)
- [x] No data, checkpoints, reports or credentials staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)