### PR TITLE
fix(mlflow): log to a database, because the filesystem backend now refuses writes

### DIFF
--- a/docs/PHASED_PLAN.md
+++ b/docs/PHASED_PLAN.md
@@ -271,7 +271,9 @@ Prompt: [`docs/prompts/2026-08-16-github-management.md`](prompts/2026-08-16-gith
   broken and the noise floor is unknown produces a comparison that says nothing.
 - **No second dataset** until the first one is hash-addressable.
 - **No new dashboard surface.** Assemble before building: MLflow owns metrics history
-  and is already wired but refused the last run (it needs a SQLite backing store, not
-  the filesystem backend). Fixing that is smaller than any panel that would duplicate it.
+  and is already wired. It refused the last run — mlflow 3.15 answers a `file://`
+  tracking URI with "the filesystem tracking backend is in maintenance mode" — and now
+  writes to `sqlite:///pipeline/mlruns/mlflow.db`, with the artifact location named
+  explicitly rather than left to resolve against whatever CWD a subprocess had.
 - **No hosted tracker.** W&B / Comet / Neptune are rejected on the credentials rule,
   not on quality.

--- a/pipeline/mlflow_sink.py
+++ b/pipeline/mlflow_sink.py
@@ -20,7 +20,13 @@ EXPERIMENT = "federated-yolov8"
 
 def _mlflow():
     import mlflow  # lazy: importing mlflow costs ~2s, and --list should stay instant
-    mlflow.set_tracking_uri(paths.MLFLOW_STORE.as_uri())
+    mlflow.set_tracking_uri(paths.mlflow_uri())
+    if mlflow.get_experiment_by_name(EXPERIMENT) is None:
+        # Named explicitly. A database backend does not imply where artifacts go, and
+        # the default is `./mlartifacts` relative to the CWD -- which for this project
+        # means one directory per place a subprocess was launched from.
+        paths.MLFLOW_ARTIFACTS.mkdir(parents=True, exist_ok=True)
+        mlflow.create_experiment(EXPERIMENT, artifact_location=paths.MLFLOW_ARTIFACTS.as_uri())
     mlflow.set_experiment(EXPERIMENT)
     return mlflow
 

--- a/pipeline/paths.py
+++ b/pipeline/paths.py
@@ -14,6 +14,8 @@ PROJECT = REPO / "my-project"          # invoked, never modified
 HERE = Path(__file__).resolve().parent
 STATE = HERE / ".state"            # markers + attribute cache; gitignored
 MLFLOW_STORE = HERE / "mlruns"     # gitignored
+MLFLOW_DB = MLFLOW_STORE / "mlflow.db"
+MLFLOW_ARTIFACTS = MLFLOW_STORE / "artifacts"
 REPORTS = HERE / "reports"         # gitignored
 # Vehicle shards live here, NOT in my-project. task.get_batch_path() resolves
 # FL_AV_DATA_ROOT/batch/batch_<id>, so pointing that env var at VEHICLE_ROOT is all
@@ -47,6 +49,23 @@ def find_label_jsons() -> list[Path]:
     if not _CACHE.is_dir():
         return []
     return sorted(_CACHE.glob(f"versions/*/{LABELS_DIR_NAME}/**/bdd100k_labels_images_*.json"))
+
+
+def mlflow_uri() -> str:
+    """SQLite, not the filesystem store.
+
+    mlflow 3.15 refuses the file:// backend outright -- "The filesystem tracking
+    backend (e.g., './mlruns') is in maintenance mode and will not receive further
+    updates" -- so the sink this project wired up logged nothing for a whole six-round
+    run and the failure was a line in a stage log.
+
+    Absolute and POSIX-slashed on purpose: SQLAlchemy reads everything after
+    ``sqlite:///`` as a path, a Windows backslash escapes inside it, and a relative one
+    would put a database wherever the subprocess happened to be standing -- which is
+    the trap that has already truncated this project's metrics.csv once.
+    """
+    MLFLOW_STORE.mkdir(parents=True, exist_ok=True)
+    return f"sqlite:///{MLFLOW_DB.as_posix()}"
 
 
 def log_dirs() -> list[Path]:
@@ -101,7 +120,10 @@ def subprocess_env(ray_address: str | None = None, data_root: Path | None = None
             if p and os.path.normcase(p) != same]
     env["PATH"] = os.pathsep.join([scripts, *rest])
     env["FL_AV_DATA_ROOT"] = str(data_root or PROJECT)
-    env.setdefault("MLFLOW_TRACKING_URI", MLFLOW_STORE.as_uri())
+    # Ultralytics' own MLflow callback reads this. It has to name the same backend the
+    # pipeline's sink writes to, or the two halves of a run -- per-vehicle training
+    # curves and federation-level facts -- land in two stores and neither is complete.
+    env.setdefault("MLFLOW_TRACKING_URI", mlflow_uri())
     if ray_address:
         # Makes flwr's ray.init() attach to an already-running head node instead
         # of creating its own with include_dashboard=False hardcoded.

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -1731,6 +1731,24 @@ def test_with_no_real_run_at_all_the_checksums_are_empty_not_wrong(tmp_path):
     assert logparse.federation_learned(tmp_path)[0] is False
 
 
+def test_the_mlflow_backend_is_a_database_because_the_filesystem_one_refuses_writes(monkeypatch):
+    """mlflow 3.15 answers a file:// tracking URI with "The filesystem tracking backend
+    (e.g., './mlruns') is in maintenance mode", so the sink logged nothing for an
+    entire six-round run. The URI must also be absolute and POSIX-slashed: a Windows
+    backslash escapes inside a SQLAlchemy URL, and a relative one puts a database
+    wherever the subprocess was standing."""
+    uri = paths.mlflow_uri()
+    assert uri.startswith("sqlite:///"), uri
+    assert "\\" not in uri, uri
+    assert Path(uri.removeprefix("sqlite:///")).is_absolute(), uri
+
+    # Ultralytics' callback reads the env var; the sink calls the function. If those
+    # two disagree, a run's training curves and its federation facts land in different
+    # stores and every chart is half a run.
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    assert paths.subprocess_env()["MLFLOW_TRACKING_URI"] == uri
+
+
 def test_a_refused_run_does_not_become_the_config_the_plan_previews():
     """/api/run validated the config it had already adopted, so a POST the server
     refused with a 400 still replaced the global one -- and /api/plan then previewed


### PR DESCRIPTION
## What was wrong or missing

Backlog 80. The MLflow sink was wired and logged **nothing** for an entire six-round run. Reproduced before fixing:

```
$ python -c "import mlflow; mlflow.set_tracking_uri(p.as_uri()); mlflow.set_experiment('probe')"
FILE BACKEND REFUSED: MlflowException The filesystem tracking backend (e.g., './mlruns')
is in maintenance mode and will not receive further updates. Please migrate to a
database backend (e.g., 'sqlite:///mlflow.db')
```

mlflow 3.15.1, installed in the project venv.

## What changed

`paths.mlflow_uri()` returns a SQLite URI, and the sink names the artifact location explicitly. Three details, each an instance of a trap this project already has:

- **Absolute and POSIX-slashed.** SQLAlchemy reads everything after `sqlite:///` as a path, a Windows backslash escapes inside it, and a relative one opens a database wherever the subprocess was standing — the class of bug that truncated a live run's `metrics.csv`.
- **`subprocess_env` hands the same URI to ultralytics' own callback.** The two writers are meant to share one experiment; different backends would give every chart half a run and look like sparse data rather than a bug.
- **The artifact location is named.** A database backend does not imply where artifacts go, and the default resolves against the CWD.

## How it was verified

Against the real repo paths, not a temp directory:

```
$ python -c "from pipeline import mlflow_sink, paths; ..."
uri       = sqlite:///C:/.../federated-yolov8/pipeline/mlruns/mlflow.db
runs      = 1
energy    = [82.2]
artifacts = file:///C:/.../federated-yolov8/pipeline/mlruns/artifacts

$ python -m pytest my-project/tests pipeline/tests -q
167 passed in 2.24s
```

Both paths stay under `pipeline/mlruns/`, already gitignored at line 204.

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke
- [x] Docs updated in this PR (`docs/PHASED_PLAN.md`)
- [x] No data, checkpoints, reports or credentials staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)