### PR TITLE
fix(mlflow): one store, and a federation actually recorded in it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,9 @@ certs/
 # artifacts, and reports are per-run output.
 pipeline/vehicles/
 pipeline/mlruns/
+# Ultralytics' MLflow callback runs with cwd=my-project. Until it is pointed at the
+# pipeline's experiment it drops artifacts here, and a stray store is still a store.
+my-project/mlruns/
 pipeline/reports/
 pipeline/.state/
 pipeline/**/__pycache__/

--- a/pipeline/mlflow_sink.py
+++ b/pipeline/mlflow_sink.py
@@ -15,7 +15,20 @@ from pathlib import Path
 
 from . import logparse, paths
 
-EXPERIMENT = "federated-yolov8"
+EXPERIMENT = paths.MLFLOW_EXPERIMENT
+
+
+def ensure_experiment() -> None:
+    """Create the experiment, with its artifact location named, before anything logs.
+
+    Order matters and it is the whole reason this is callable on its own. Ultralytics'
+    callback calls ``set_experiment`` too, and whoever gets there first decides where
+    artifacts live. If that is the callback -- running with ``cwd=my-project`` and no
+    artifact location -- MLflow resolves them against the CWD and a federation leaves
+    24 run directories under ``my-project/mlruns/``, outside the store the sink writes
+    to. The pipeline therefore creates the experiment before it launches a stage.
+    """
+    _mlflow()
 
 
 def _mlflow():
@@ -23,8 +36,8 @@ def _mlflow():
     mlflow.set_tracking_uri(paths.mlflow_uri())
     if mlflow.get_experiment_by_name(EXPERIMENT) is None:
         # Named explicitly. A database backend does not imply where artifacts go, and
-        # the default is `./mlartifacts` relative to the CWD -- which for this project
-        # means one directory per place a subprocess was launched from.
+        # the default resolves against the CWD -- which for this project means one
+        # store per place a subprocess was launched from.
         paths.MLFLOW_ARTIFACTS.mkdir(parents=True, exist_ok=True)
         mlflow.create_experiment(EXPERIMENT, artifact_location=paths.MLFLOW_ARTIFACTS.as_uri())
     mlflow.set_experiment(EXPERIMENT)

--- a/pipeline/paths.py
+++ b/pipeline/paths.py
@@ -16,6 +16,11 @@ STATE = HERE / ".state"            # markers + attribute cache; gitignored
 MLFLOW_STORE = HERE / "mlruns"     # gitignored
 MLFLOW_DB = MLFLOW_STORE / "mlflow.db"
 MLFLOW_ARTIFACTS = MLFLOW_STORE / "artifacts"
+#: One experiment for both writers -- ultralytics' per-vehicle training curves and
+#: the sink's federation-level facts. Lives here rather than in mlflow_sink because
+#: subprocess_env has to name it too, and a constant in two places is a constant that
+#: will disagree with itself.
+MLFLOW_EXPERIMENT = "federated-yolov8"
 REPORTS = HERE / "reports"         # gitignored
 # Vehicle shards live here, NOT in my-project. task.get_batch_path() resolves
 # FL_AV_DATA_ROOT/batch/batch_<id>, so pointing that env var at VEHICLE_ROOT is all
@@ -120,10 +125,19 @@ def subprocess_env(ray_address: str | None = None, data_root: Path | None = None
             if p and os.path.normcase(p) != same]
     env["PATH"] = os.pathsep.join([scripts, *rest])
     env["FL_AV_DATA_ROOT"] = str(data_root or PROJECT)
-    # Ultralytics' own MLflow callback reads this. It has to name the same backend the
-    # pipeline's sink writes to, or the two halves of a run -- per-vehicle training
-    # curves and federation-level facts -- land in two stores and neither is complete.
+    # Ultralytics' own MLflow callback reads both of these. The URI has to name the
+    # same backend the pipeline's sink writes to, or the two halves of a run --
+    # per-vehicle training curves and federation-level facts -- land in two stores and
+    # neither is complete.
+    #
+    # The experiment name matters for a second reason. Without it the callback falls
+    # back to `trainer.args.project`, creates an experiment of its own with no artifact
+    # location, and MLflow then resolves artifacts against the CWD -- which for every
+    # stage in this pipeline is my-project. One federation left 24 run directories under
+    # my-project/mlruns/, outside the store, ungitignored and invisible to the sink.
+    # Naming the sink's experiment reuses its explicit artifact location instead.
     env.setdefault("MLFLOW_TRACKING_URI", mlflow_uri())
+    env.setdefault("MLFLOW_EXPERIMENT_NAME", MLFLOW_EXPERIMENT)
     if ray_address:
         # Makes flwr's ray.init() attach to an already-running head node instead
         # of creating its own with include_dashboard=False hardcoded.

--- a/pipeline/report.py
+++ b/pipeline/report.py
@@ -21,9 +21,9 @@ from . import baseline, gpu, holdout, logparse, paths, vehicle_metrics, vehicles
 def collect(config: dict | None = None, telemetry: dict | None = None,
             results: list[dict] | None = None) -> dict:
     """Gather everything the report shows, from files on disk."""
-    from .verify import _metrics_csv
+    from .verify import metrics_csv
     checksums = logparse.aggregate_checksums()
-    rows = logparse.read_metrics_csv(_metrics_csv())
+    rows = logparse.read_metrics_csv(metrics_csv())
     learned, detail = logparse.federation_learned()
 
     per_vehicle: dict[int, dict] = {}

--- a/pipeline/runner.py
+++ b/pipeline/runner.py
@@ -129,6 +129,7 @@ class Run:
     def execute(self, chain: list[Stage]) -> bool:
         self.sampler.start()
         self.emit("run_start", config=self.cfg.to_dict(), stages=[s.name for s in chain])
+        self._prepare_mlflow(chain)
         ok = True
         try:
             for stage in chain:
@@ -145,12 +146,55 @@ class Run:
         finally:
             telemetry = self.sampler.stop()
             self._restore_pyproject()
+            self._log_to_mlflow(telemetry.summary())
             report_paths = self._write_report(telemetry.summary())
             self.emit("run_end", ok=ok, seconds=round(time.time() - self.started, 1),
                       gpu=telemetry.summary(),
                       report=[str(p) for p in report_paths],
                       results=[r.__dict__ for r in self.results])
         return ok
+
+    def _federated(self) -> bool:
+        return any(r.name == "federate" and r.status == "ok" for r in self.results)
+
+    def _prepare_mlflow(self, chain: list[Stage]) -> None:
+        """Create the experiment before any stage can, so artifacts land in one store.
+
+        Ultralytics' callback calls set_experiment too, from a subprocess whose CWD is
+        my-project. Whichever call happens first fixes the artifact location for good.
+        """
+        if not any(s.name == "federate" for s in chain):
+            return
+        try:
+            from . import mlflow_sink
+            mlflow_sink.ensure_experiment()
+        except Exception as e:
+            self.emit("log", line=f"mlflow: experiment not prepared ({type(e).__name__}: {e})")
+
+    def _log_to_mlflow(self, telemetry: dict) -> None:
+        """The federation-level facts no single training run can see.
+
+        Ultralytics logs the per-vehicle curves on its own. This logs what only the
+        server knows -- the round-over-round aggregate checksum, which is the one
+        signal that distinguishes a federation that learns from one that averages its
+        own input -- plus what the whole run cost in watt-hours.
+
+        The sink has existed since the observability work and nothing ever called it,
+        so MLflow held training curves and no federation at all.
+        """
+        if not self._federated():
+            return
+        try:
+            from . import mlflow_sink, verify
+            with mlflow_sink.run(f"federation-{int(self.started)}", self.cfg.to_dict()):
+                mlflow_sink.log_federation(None, verify.metrics_csv())
+                mlflow_sink.log_gpu(telemetry)
+        except Exception as e:
+            # Never fail a run over telemetry -- but never swallow it either. The last
+            # time MLflow refused a write, the only trace was one line in a stage log
+            # and six rounds of federation facts were simply not recorded.
+            self.emit("log", line=f"mlflow: run not logged ({type(e).__name__}: {e})")
+            print(f"\n!! mlflow: run not logged ({type(e).__name__}: {e})", file=sys.stderr)
 
     def _write_report(self, telemetry: dict) -> list[Path]:
         """Always write the report, including for a failed run -- that is when the

--- a/pipeline/server.py
+++ b/pipeline/server.py
@@ -106,7 +106,7 @@ class State:
         still shows up. The event bus stays for the low-latency log stream.
         """
         checksums = logparse.aggregate_checksums()
-        metrics_path = verify._metrics_csv()
+        metrics_path = verify.metrics_csv()
         rows = logparse.read_metrics_csv(metrics_path)
 
         per_vehicle: dict[str, dict] = {}

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -555,7 +555,7 @@ def test_live_state_is_derived_from_disk_not_from_the_event_bus(monkeypatch, tmp
         "1,evaluate,6,0.5,0.4,0.3,0.25,0.1,0.1\n")
 
     monkeypatch.setattr(paths, "log_dirs", lambda: [logs])
-    monkeypatch.setattr(_verify, "_metrics_csv", lambda: logs / "metrics.csv")
+    monkeypatch.setattr(_verify, "metrics_csv", lambda: logs / "metrics.csv")
 
     live = server.State().live()
     assert live["rounds_done"] == 2
@@ -1783,6 +1783,49 @@ def test_the_mlflow_backend_is_a_database_because_the_filesystem_one_refuses_wri
     # stores and every chart is half a run.
     monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
     assert paths.subprocess_env()["MLFLOW_TRACKING_URI"] == uri
+
+
+def test_a_federation_that_ran_is_actually_written_to_mlflow(monkeypatch):
+    """pipeline.mlflow_sink has existed since the observability work and nothing ever
+    called it, so MLflow held ultralytics' per-vehicle training curves and no
+    federation at all -- no round-over-round checksum, which is the one signal that
+    tells a federation that learns from one averaging its own input."""
+    import contextlib
+
+    from pipeline import mlflow_sink, runner
+
+    calls = []
+    monkeypatch.setattr(mlflow_sink, "run",
+                        lambda name, params=None, nested=False: (
+                            calls.append(("run", name)) or contextlib.nullcontext()))
+    monkeypatch.setattr(mlflow_sink, "log_federation",
+                        lambda log_dir, csv: calls.append(("federation", str(csv))))
+    monkeypatch.setattr(mlflow_sink, "log_gpu", lambda summary: calls.append(("gpu", summary)))
+
+    run = runner.Run(Config())
+    run.results = [runner.StageResult("fleet", "ok"), runner.StageResult("federate", "ok")]
+    run._log_to_mlflow({"energy_wh": 2.66})
+    assert [c[0] for c in calls] == ["run", "federation", "gpu"]
+
+    # A run that never federated has no federation facts to log, and an empty run in
+    # the store is worse than no run: it looks like a federation that recorded nothing.
+    calls.clear()
+    run.results = [runner.StageResult("fleet", "ok")]
+    run._log_to_mlflow({"energy_wh": 0.04})
+    assert calls == []
+
+
+def test_both_mlflow_writers_are_pointed_at_the_same_experiment(monkeypatch):
+    """Ultralytics' callback falls back to trainer.args.project and creates its own
+    experiment with no artifact location. MLflow then resolves artifacts against the
+    CWD, which for every stage here is my-project -- one federation left 24 run
+    directories under my-project/mlruns/, outside the store the sink reads."""
+    monkeypatch.delenv("MLFLOW_EXPERIMENT_NAME", raising=False)
+    env = paths.subprocess_env()
+    assert env["MLFLOW_EXPERIMENT_NAME"] == paths.MLFLOW_EXPERIMENT
+
+    from pipeline import mlflow_sink
+    assert mlflow_sink.EXPERIMENT == paths.MLFLOW_EXPERIMENT, "one name, defined once"
 
 
 def test_a_refused_run_does_not_become_the_config_the_plan_previews():

--- a/pipeline/verify.py
+++ b/pipeline/verify.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from . import logparse, paths
 
 
-def _metrics_csv() -> Path:
+def metrics_csv() -> Path:
     """logs/metrics.csv from whichever log dir actually has one."""
     for d in paths.log_dirs():
         if (d / "metrics.csv").exists():
@@ -38,7 +38,7 @@ def check(project: Path = paths.PROJECT) -> tuple[bool, list[str]]:
                    f"({len(recv)} received, {len(sent)} sent)")
     ok &= c2
 
-    rows = logparse.read_metrics_csv(_metrics_csv())
+    rows = logparse.read_metrics_csv(metrics_csv())
     maps = [r.get("mAP50") for r in rows if r.get("mAP50") is not None]
     c3 = len(rows) >= 2 and any(m and m > 0 for m in maps)
     results.append(f"[{'PASS' if c3 else 'FAIL'}] metrics.csv has rows with non-zero mAP50 "


### PR DESCRIPTION
## What was wrong or missing

#46 made writes possible. Running a federation showed nothing was writing the part that matters. Two defects, both found by running it rather than reading it:

1. **`pipeline/mlflow_sink.py` was never called by anything.** It has existed since the observability work. MLflow held ultralytics' per-vehicle training curves and **no federation at all** — no round-over-round aggregate checksum, which is this project's single most useful signal, and no energy figure.
2. **A federation left 24 run directories under `my-project/mlruns/`.** Ultralytics' callback falls back to `trainer.args.project` for the experiment name, creates that experiment with no artifact location, and MLflow resolves artifacts against the CWD — which for every stage here is `my-project`.

## What changed

- The runner logs federation-level facts after any run whose `federate` stage succeeded, and **refuses to open an empty run** for one that never federated: an empty run in the store reads as a federation that recorded nothing.
- Whichever caller reaches `set_experiment` first fixes the artifact location for good, so the runner creates the experiment **before** it launches a stage, and `subprocess_env` passes `MLFLOW_EXPERIMENT_NAME` so the callback joins it rather than inventing its own.
- `my-project/mlruns/` is gitignored in this commit anyway. A stray store is still a store, and the next version of a dependency can move it again.
- `verify._metrics_csv` → `verify.metrics_csv`. It had three callers outside `verify.py` already — report, server, and now the runner — so the underscore was documentation that had stopped being true.

## How it was verified

On a real demo federation, not asserted:

```
stray store present? -> NO
experiment  = federated-yolov8 | artifacts = .../pipeline/mlruns/artifacts
runs        = 14           (12 per-vehicle from ultralytics, 1 federation, 1 probe)
federation  aggregate_checksum 606.24 | gpu_energy_wh 2.6647 | learned True

$ python -m pytest my-project/tests pipeline/tests -q
171 passed in 2.75s
```

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke
- [x] Docs updated in this PR (`.gitignore`)
- [x] No data, checkpoints, reports or credentials staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)