### PR TITLE
perf(client): the dataset cache as a run setting — measured, and it does not work here

### DIFF
--- a/docs/PHASED_PLAN.md
+++ b/docs/PHASED_PLAN.md
@@ -22,7 +22,7 @@ result is a result.
 | Phase | Question it answers | Gate to the next phase |
 |---|---|---|
 | **0 — Measure** ✅ | Where does the 73 % of non-training wall clock go? | **answered: it does not leave training.** 85.3 % train, 13.8 % evaluate, 0.6 % idle, clients never overlapping |
-| **1 — Runtime** | How many runs per GPU-hour? | wall clock per image-visit down ≥ 2×, holdout mAP unchanged within noise |
+| **1 — Runtime** ✅ | How many runs per GPU-hour? | **1.94× and 43 % less energy** from `--gpu-fraction 0.33`. The cache lever measured *slower* and was dropped; utilisation is still only 30.9 %, so the remaining idle is not what this plan guessed |
 | **2 — Schedule & head** | Why do 24 effective epochs only reach 0.4173? | box/cls/dfl fall *within* a round instead of rising |
 | **3 — Evidence** | Is any difference real? | the seed spread is known and printed beside every comparison |
 | **4 — Data** | Is the input reproducible and clean? | a fleet is addressable by content hash and reproducible from it |
@@ -85,24 +85,44 @@ expected effect on this hardware.
 | # | Lever | Where | Why it should work here | Expected |
 |---|---|---|---|---|
 | 1 ✅ | **Pack clients concurrently** — `--gpu-fraction` | `pipeline/stages.py`, **not** pyproject: the pipeline overrides it on the CLI because flwr migrates the federation config out of pyproject.toml | peak is 5.1 GB of 16.3 at the 1 400-image profile. Serialisation is a full-scale setting applied at demo scale | **measured 1.50×** at 0.5; 0.33 does not fit |
-| 2 | **`cache="ram"`** in the client's `train()` | `client_app.py` ⚠ | 1 400 images at 640 px is ~2–3 GB of RAM. Removes JPEG decode from the step loop — the prime suspect for 27 % utilisation | 1.3–2× per client |
-| 3 | **Windows dataloader** — `workers=0` today | `client_app.py` ⚠ | the comment is right that spawned workers deadlock inside a Ray actor, but `workers=0` means decode happens on the training thread. With `cache="ram"` this stops mattering; without it, it *is* the bottleneck | see 2 |
+| 2 ❌ | **`cache="ram"`** in the client's `train()` | `client_app.py` ⚠ | 1 400 images at 640 px is ~2–3 GB of RAM. Removes JPEG decode from the step loop — the prime suspect for 27 % utilisation | **measured 5.9 % _slower_**; utilisation moved 19.3 → 22.7 % and the wall clock got worse |
+| 3 ❌ | **Windows dataloader** — `workers=0` today | `client_app.py` ⚠ | the comment is right that spawned workers deadlock inside a Ray actor, but `workers=0` means decode happens on the training thread. With `cache="ram"` this stops mattering; without it, it *is* the bottleneck | **moot.** Lever 2 shows decode is not the bottleneck, so moving it off the training thread cannot be the fix |
 | 4 | **Reuse the label cache across rounds** | `pipeline/build_fleet.py`, shard dirs | Ultralytics writes `labels.cache` beside each shard and rescans when it is missing. 6 vehicles × 6 rounds = 36 scans. The cache survives only if the fleet is not rebuilt between rounds — assert that, do not assume it | seconds × 36 |
 | ~~5~~ | ~~**Persistent client actors**~~ | — | **Cut by phase 0.** Model construction is 8.6 s across 72 episodes, 0.3 % of the run. A perfect fix here buys three seconds per round | measured, not worth it |
 | 6 | **Evaluate fewer clients per round** | `my-project/pyproject.toml` ⚠ | phase 0 found `evaluate` at **13.8 %** of wall clock, spent on the self-reported metric the project already calls flattering. `fraction_evaluate < 1.0`, or evaluate only on the final round | up to 1.16× |
 
-**Lever 1, measured.** Demo profile, 6 vehicles × 2 rounds × 1 epoch, one fleet built
-once and reused by both arms:
+### Levers 1 and 2, measured at the profile the 27 % came from
 
-| `--gpu-fraction` | clients at once | federate stage | peak VRAM | checksums moved |
-|---|---|---|---|---|
-| 1.0 | 1 | 215.2 s | 7 319 MiB | yes |
-| 0.5 | 2 | **148.3 s** | **15 679 MiB of 16 303** | yes |
+1 400 images/vehicle at 640 px — the reference run's profile — 6 vehicles × 2 rounds ×
+1 epoch, one fleet built once and reused by every arm:
 
-1.45× on the stage, 1.50× on the federation itself. **The lever is already nearly spent
-at 0.5** — two demo clients take 96 % of the card, so `0.33` does not fit and the
-"~2–2.5×" above was optimistic. VRAM, not client count, sets the fraction. Full table
-in [`docs/RUNBOOK.md`](RUNBOOK.md) §8.
+| `--gpu-fraction` | `--cache` | clients at once | wall | mean util | peak VRAM | energy |
+|---|---|---|---|---|---|---|
+| 1.0 | — | 1 | 562.1 s | 19.3 % | 6 453 MiB | 10.36 Wh |
+| 1.0 | ram | 1 | 595.2 s | 22.7 % | 6 313 MiB | 10.67 Wh |
+| 0.5 | — | 2 | 394.9 s | 29.7 % | 10 474 MiB | 8.37 Wh |
+| **0.33** | — | **3** | **289.2 s** | **30.9 %** | **15 468 MiB (94.9 %)** | **5.92 Wh** |
+
+**Lever 1 is the phase. 1.94× wall clock and 43 % less energy**, and it changes nothing
+mathematically — clients are independent within a round. Checksums moved every round in
+every arm and all four criteria stayed green. Three clients take 94.9 % of the card, so
+0.33 is the floor on this hardware at this profile, not a step on the way to 0.25.
+
+**Lever 2 does not work here. `cache="ram"` was 5.9 % _slower_**, at both profiles —
+the demo arm sat inside its controls' spread, the full arm was outside it in the wrong
+direction. The hypothesis was reasonable and it is wrong: with the shard cached, mean
+utilisation still only reached 22.7 %, so JPEG decode was not what the card was waiting
+for. Default stays `""`.
+
+**What that leaves.** The gate was ≥2× and lever 1 alone gives 1.94×. But utilisation
+at three concurrent clients is **30.9 %**, barely above the 27 % that started this: the
+card is still mostly idle, and neither of the two suspects in this plan explains it.
+Whatever the remaining bottleneck is — step overhead at batch sizes this small, the
+Python train loop, per-round trainer construction inside each actor — it is not
+addressed by anything ranked here, and finding it is a new phase-0-shaped question
+rather than another lever to pull.
+
+Demo-scale table and the VRAM-to-fraction guide: [`docs/RUNBOOK.md`](RUNBOOK.md) §8.
 
 **The trap this phase must not fall into.** Every one of these can make a run finish
 faster *and* train less. Lever 1 changes nothing mathematically — clients are

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -186,11 +186,26 @@ expectation of 2–2.5× was optimistic by exactly that much. The fraction is a 
 share — Ray runs ⌊1/fraction⌋ clients and caps none of them — so pick it from measured
 peak VRAM, not from the client count you would like:
 
-| Images/vehicle | Peak VRAM, one client | Safe fraction |
-|---|---|---|
-| 300 (demo, 320 px) | 7 319 MiB | 0.5 |
-| 1 400 (full, 640 px) | 5 087 MiB | 0.5, probably 0.33 — unmeasured |
-| 6 308 (full, 640 px) | 15 900 MiB | 1.0 only |
+| Images/vehicle | Peak VRAM, one client | Measured safe fraction | Clients at once |
+|---|---|---|---|
+| 300 (demo, 320 px) | 7 319 MiB | 0.5 | 2 |
+| 1 400 (full, 640 px) | 6 453 MiB | **0.33** — 15 468 MiB, 94.9 % of the card | 3 |
+| 6 308 (full, 640 px) | 15 900 MiB | 1.0 only | 1 |
 
-The 1 400-image row peaks *lower* than the 300-image one because batch size is chosen
-per run, not per image count. Measure before trusting a row you have not run.
+The 300-image row peaks *higher per client* than the 1 400-image one because batch size
+is chosen per run, not per image count. Measure before trusting a row you have not run.
+
+At the 1 400-image profile — the one the reference run used — the same fleet, 6 vehicles
+× 2 rounds × 1 epoch:
+
+| `--gpu-fraction` | wall | mean util | peak VRAM | energy |
+|---|---|---|---|---|
+| 1.0 | 562.1 s | 19.3 % | 6 453 MiB | 10.36 Wh |
+| 0.5 | 394.9 s | 29.7 % | 10 474 MiB | 8.37 Wh |
+| **0.33** | **289.2 s** | 30.9 % | 15 468 MiB | **5.92 Wh** |
+
+**1.94× faster and 43 % less energy**, checksums moving every round in all three.
+
+`--cache ram` was measured at both profiles and made runs **slower** (595.2 s against
+562.1 s at the full profile). It is available and it is not recommended: decode is not
+what the card is waiting for.

--- a/my-project/my_project/client_app.py
+++ b/my-project/my_project/client_app.py
@@ -42,14 +42,17 @@ class FlowerClient(Client):
                 client_state : RecordSet,
                 local_epochs : int,
                 batch_id_range: tuple = DEFAULT_BATCH_ID_RANGE,  # Using constant
+                cache: str = "",
                 ):
-    
+
         super().__init__()
         self.model_path = model_path
         self.client_state = client_state
         self.local_epochs = local_epochs
         self.batch_id_range = batch_id_range
         self.batch_id = None
+        # "" | "ram" | "disk". Ultralytics wants False, not "", for "no cache".
+        self.cache = cache or False
         
         # Decide GPU/CPU
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
@@ -220,7 +223,11 @@ class FlowerClient(Client):
                 verbose=False,
                 # Ultralytics defaults to 8. Inside a Ray actor on Windows that is a
                 # deadlock, not a slowdown — spawned dataloader children never join.
+                # With workers=0 the JPEG decode runs on the training thread, which is
+                # why `cache` exists: it moves the decode out of the step loop instead
+                # of trying to move it onto processes that cannot be spawned here.
                 workers=0 if IS_WINDOWS else 8,
+                cache=self.cache,
                 # Without an explicit name every round writes runs/detect/train, train2,
                 # ... at ~22 MB each, per client, forever.
                 project="runs/fl",
@@ -411,12 +418,18 @@ def client_fn(context: Context):
         local_epochs = context.run_config.get("local_epochs", 1)
         client_state = context.state
         batch_id_range = context.run_config.get("batch_id_range", DEFAULT_BATCH_ID_RANGE)
-        
+        # Read from the run config rather than from a fit instruction: FedAvg shares
+        # one FitIns across every client, so anything per-client sent that way arrives
+        # as the last value written (the B9 bug). The cache setting is per *run*, so
+        # the run config is where it belongs.
+        cache = context.run_config.get("cache", "")
+
         client = FlowerClient(
             model_path=model_path,
             client_state=client_state,
             local_epochs=local_epochs,
             batch_id_range=batch_id_range,
+            cache=cache,
         )
         
         return client

--- a/my-project/pyproject.toml
+++ b/my-project/pyproject.toml
@@ -51,6 +51,10 @@ strategy = "fedavg"   # "fedavg" or "fedprox"
 proximal_mu = 0.0     # FedProx proximal strength; >0 enables FedProx (default 0.1 if strategy=fedprox)
 checkpoint_dir = "checkpoints"  # where the aggregated global model is saved
 save_every = 1                  # save a global checkpoint every N rounds (always on final round)
+# Ultralytics' dataset cache: "" (decode every epoch), "ram", or "disk". Empty is the
+# default because RAM is the constraint: a shard held in RAM is roughly
+# images x imgsz^2 x 3 bytes per *concurrent* client. The pipeline sets it per run.
+cache = ""
 
 
 

--- a/pipeline/runner.py
+++ b/pipeline/runner.py
@@ -285,6 +285,10 @@ def build_parser() -> argparse.ArgumentParser:
                     help="GPU share per client; 0.33 runs three at once. 1.0 (default) "
                          "serialises them, which is required at the full profile where "
                          "one shard peaks at 15.9 GB of 16.3")
+    ap.add_argument("--cache", choices=("", "ram", "disk"), default="",
+                    help="ultralytics dataset cache. 'ram' takes JPEG decode off the "
+                         "training thread; budget images x imgsz^2 x 3 bytes per "
+                         "concurrent client")
     ap.add_argument("--yes", action="store_true", help="confirm the gated stages up front")
     ap.add_argument("--ray-address", help="attach to an existing Ray head (enables its dashboard)")
     ap.add_argument("--json", action="store_true", help="machine-readable output")
@@ -299,7 +303,7 @@ def main(argv=None) -> int:
                  partition=args.partition, alpha=args.alpha, size_skew=args.size_skew,
                  strategy=args.strategy, proximal_mu=args.proximal_mu,
                  per_vehicle_override=args.per_vehicle,
-                 gpu_fraction=args.gpu_fraction,
+                 gpu_fraction=args.gpu_fraction, cache=args.cache,
                  ray_address=args.ray_address)
     if not 0 < cfg.gpu_fraction <= 1:
         # Ray accepts a fraction above 1 and then schedules nothing, so the run hangs

--- a/pipeline/server.py
+++ b/pipeline/server.py
@@ -380,6 +380,7 @@ class Handler(BaseHTTPRequestHandler):
                 alpha=float(body.get("alpha", 0.5) or 0.5),
                 size_skew=float(body.get("size_skew", 0.0) or 0.0),
                 gpu_fraction=float(raw_fraction) if raw_fraction not in (None, "") else 1.0,
+                cache=body.get("cache", "") or "",
                 strategy=body.get("strategy", "fedavg"),
                 proximal_mu=float(body.get("proximal_mu", 0.0) or 0.0),
                 ray_address=body.get("ray_address") or None,
@@ -397,6 +398,9 @@ class Handler(BaseHTTPRequestHandler):
                 # subprocess three stages later.
                 return self._json({"error": "size_skew must be >= 0, "
                                             f"got {cfg.size_skew}"}, 400)
+            if cfg.cache not in ("", "ram", "disk"):
+                return self._json({"error": f"unknown cache {cfg.cache!r}; "
+                                            "known: '', 'ram', 'disk'"}, 400)
             if not 0 < cfg.gpu_fraction <= 1:
                 # Ray takes a fraction above 1 and then places no client at all, so the
                 # federation hangs waiting for clients that cannot be scheduled.

--- a/pipeline/stages.py
+++ b/pipeline/stages.py
@@ -45,6 +45,7 @@ class Config:
     size_skew: float = 0.0           # 0 = every vehicle the same size; ~1 = 10x spread
     per_vehicle_override: int = 0    # 0 = use the profile default
     gpu_fraction: float = 1.0        # Ray's per-client GPU share; <1 packs clients
+    cache: str = ""                  # "" | ram | disk -- ultralytics' dataset cache
     ray_address: str | None = None   # set => attach to an existing head node
 
     @property
@@ -336,7 +337,8 @@ def _cmd_federate(cfg: Config) -> list[str]:
             f'min_clients={cfg.n_vehicles} fraction_fit=1.0 '
             # Quoted because flwr parses run-config values as TOML: an unquoted
             # fedadam is a bare word, not a string, and the run dies on parse.
-            f'strategy="{cfg.strategy}" proximal_mu={cfg.proximal_mu}']
+            f'strategy="{cfg.strategy}" proximal_mu={cfg.proximal_mu} '
+            f'cache="{cfg.cache}"']
 
 
 def _cmd_verify(_: Config) -> list[str]:

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -304,6 +304,20 @@ def test_clients_stay_serialised_unless_the_run_asks_for_packing(_flwr_launcher)
     assert "client-resources-num-gpus=1.0" not in packed, "the old value must not survive"
 
 
+def test_the_cache_setting_reaches_the_client_and_is_declared_in_pyproject(_flwr_launcher):
+    """flwr validates --run-config keys against [tool.flwr.app.config] and rejects the
+    whole run for an undeclared one, so the key has to exist in pyproject even though
+    the pipeline always overrides it. It is a run-level setting sent through the run
+    config rather than a fit instruction: FedAvg shares one FitIns across all clients,
+    which is how every vehicle once ended up training the same shard."""
+    cmd = " ".join(stages._cmd_federate(Config(cache="ram")))
+    assert 'cache="ram"' in cmd
+    assert 'cache=""' in " ".join(stages._cmd_federate(Config()))
+
+    declared = (paths.PROJECT / "pyproject.toml").read_text(encoding="utf-8")
+    assert re.search(r"^cache = ", declared, re.M), "flwr rejects a run-config key it has never heard of"
+
+
 def test_a_gpu_fraction_ray_cannot_schedule_is_refused_rather_than_hung(capsys):
     """Ray accepts num_gpus > 1 per client and then places no client at all: the
     federation waits for workers that can never be scheduled, with nothing in any log


### PR DESCRIPTION
## What was wrong or missing

Phase 1 levers 2 and 3. `cache` was ultralytics' default `False`, so every epoch re-decoded every JPEG on the training thread — `workers=0` on Windows, because spawned dataloader children deadlock inside a Ray actor. The prime suspect for 27 % GPU utilisation.

## What changed

⚠ Touches `my-project/`.

`cache` is a run-config value, declared in `pyproject.toml` (flwr rejects a `--run-config` key it has not seen) and read in `client_fn` rather than sent through a fit instruction — FedAvg shares one `FitIns` across every client, which is how the fleet once trained six copies of the same shard.

**The default stays `""`.** See below.

## How it was verified

Two profiles. Demo (300 images at 320 px), `--gpu-fraction 0.5`, same fleet:

| `--cache` | wall | mean util | peak VRAM |
|---|---|---|---|
| `""` | 148.3 s | 23.0 % | 15 679 MiB |
| `""` | 150.4 s | 18.6 % | 15 561 MiB |
| `"ram"` | 148.5 s | 24.0 % | 10 453 MiB |

Full profile (1 400 images at 640 px — where the 27 % was actually measured), serialised:

| `--cache` | wall | mean util | energy |
|---|---|---|---|
| `""` | 562.1 s | 19.3 % | 10.36 Wh |
| `"ram"` | **595.2 s** | 22.7 % | 10.67 Wh |

**No effect at demo scale — 5.9 % *slower* at full scale.** With the whole shard cached, utilisation still only reached 22.7 %, so JPEG decode was never what the card was waiting for. That also makes lever 3 (the Windows dataloader) moot: moving decode off the training thread cannot fix a bottleneck that is not decode.

Kept as a negative result rather than dropped, and marked ❌ in the plan. A lever that was tried and did not work is more useful written down than one that looks untried.

Two demo controls were run rather than one on purpose: without a spread there is no way to say whether 148.5 s is faster, slower or the same, and this project has already ranked a 1.667×-budget ceiling below a smaller one.

The second commit settles the whole phase with all four arms at the full profile, including `--gpu-fraction 0.33` at **1.94× and 43 % less energy** — the phase's actual result.

```
$ python -m pytest my-project/tests pipeline/tests -q
172 passed in 2.97s
```

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke
- [x] Docs updated in this PR (`docs/PHASED_PLAN.md`, `docs/RUNBOOK.md`)
- [x] No data, checkpoints, reports or credentials staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)