### PR TITLE
fix(runner): restoring pyproject no longer throws away an uncommitted edit

### DIFF
--- a/pipeline/runner.py
+++ b/pipeline/runner.py
@@ -11,7 +11,6 @@ import json
 import os
 import sys
 import queue
-import shutil
 import subprocess
 import threading
 import time
@@ -46,6 +45,10 @@ class Run:
         self.current: str | None = None
         self._proc: subprocess.Popen | None = None
         self._stop = threading.Event()
+        # Snapshotted at construction rather than read back from git, so that restoring
+        # flwr's rewrite cannot also revert an uncommitted edit. See _restore_pyproject.
+        pp = paths.PROJECT / "pyproject.toml"
+        self._pyproject_before: bytes | None = pp.read_bytes() if pp.exists() else None
 
     # -- event plumbing ----------------------------------------------------
     def emit(self, kind: str, **payload) -> None:
@@ -236,18 +239,25 @@ class Run:
         except (OSError, subprocess.SubprocessError) as e:
             self.emit("log", stage="federate", line=f"could not stop superlink: {e}")
 
-    @staticmethod
-    def _restore_pyproject() -> None:
+    def _restore_pyproject(self) -> None:
         """`flwr run` comments out [tool.flwr.federations] in place. Put it back.
 
         Committing the rewritten file leaves a fresh clone with no federation to run,
         which has already happened once in this repo's history.
+
+        Restored from a snapshot taken before the run, not with `git checkout --`.
+        Checkout restores the *committed* file, so it discards every uncommitted edit
+        to it as well as flwr's rewrite. That is not hypothetical: adding a run-config
+        key to pyproject and then running the pipeline to test it deleted the key, and
+        the next run failed on a config value that had been there minutes earlier.
+        The snapshot also means the restore works in a source tarball with no git.
         """
         pp = paths.PROJECT / "pyproject.toml"
-        if pp.exists() and "CONFIGURATION MIGRATION NOTICE" in pp.read_text(errors="replace"):
-            if shutil.which("git"):
-                subprocess.run(["git", "checkout", "--", str(pp)], cwd=paths.REPO,
-                               capture_output=True)
+        if self._pyproject_before is None or not pp.exists():
+            return
+        if "CONFIGURATION MIGRATION NOTICE" not in pp.read_text(errors="replace"):
+            return          # flwr left it alone; anything on disk now is the user's
+        pp.write_bytes(self._pyproject_before)
 
 
 # --------------------------------------------------------------------------

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -304,6 +304,33 @@ def test_clients_stay_serialised_unless_the_run_asks_for_packing(_flwr_launcher)
     assert "client-resources-num-gpus=1.0" not in packed, "the old value must not survive"
 
 
+def test_restoring_pyproject_keeps_an_uncommitted_edit(tmp_path, monkeypatch):
+    """The restore used `git checkout -- pyproject.toml`, which puts back the
+    *committed* file and so discards any uncommitted edit along with flwr's rewrite.
+    Adding a run-config key and running the pipeline to test it deleted the key, and
+    the next run failed on a value that had been on disk minutes earlier. The snapshot
+    also makes the restore work where there is no git at all -- a source tarball."""
+    from pipeline import runner
+
+    project = tmp_path / "my-project"
+    project.mkdir()
+    pp = project / "pyproject.toml"
+    monkeypatch.setattr(paths, "PROJECT", project)
+
+    pp.write_text('[tool.flwr.app.config]\ncache = ""\n\n[tool.flwr.federations]\ndefault = "x"\n')
+    run = runner.Run(Config())                      # snapshot taken here
+
+    pp.write_text("# CONFIGURATION MIGRATION NOTICE\n# [tool.flwr.federations]\n")
+    run._restore_pyproject()
+    assert 'cache = ""' in pp.read_text(), "the uncommitted key must survive the run"
+    assert "[tool.flwr.federations]" in pp.read_text(), "and flwr's rewrite must not"
+
+    # A file flwr never touched is left exactly as the run found it, edits and all.
+    pp.write_text("edited during the run\n")
+    run._restore_pyproject()
+    assert pp.read_text() == "edited during the run\n"
+
+
 def test_the_cache_setting_reaches_the_client_and_is_declared_in_pyproject(_flwr_launcher):
     """flwr validates --run-config keys against [tool.flwr.app.config] and rejects the
     whole run for an undeclared one, so the key has to exist in pyproject even though


### PR DESCRIPTION
## What was wrong or missing

The runner ran `git checkout -- my-project/pyproject.toml` to undo flwr's in-place rewrite of `[tool.flwr.federations]`. Checkout puts back the **committed** file, so it discarded every uncommitted edit to that file as well.

Not hypothetical — it cost a debugging detour this session. Adding a `cache` run-config key to pyproject and then running the pipeline to test it **deleted the key**, and the next run failed on a config value that had been on disk minutes earlier. Anyone editing that file while iterating hits the same thing, and nothing reports it: the file simply reverts.

## What changed

The runner snapshots the file at construction and writes the snapshot back only if flwr left its migration banner.

Two consequences beyond the bug: a file flwr never touched is left exactly as the run found it, and the restore now works where there is no git — a source tarball or a container image — which the old path skipped silently.

## How it was verified

```
$ python -m pytest my-project/tests pipeline/tests -q
173 passed, 2 warnings in 2.49s
```

The new test fails when only `pipeline/runner.py` is reverted:

```
$ git stash push pipeline/runner.py && python -m pytest pipeline/tests -q -k uncommitted
E       AssertionError: the uncommitted key must survive the run
1 failed
```

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke
- [x] Docs updated in this PR (n/a — no doc describes the restore mechanism)
- [x] No data, checkpoints, reports or credentials staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)