### PR TITLE
feat(head): start the detector from COCO rows instead of from noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ to be wrong quietly.
 | 3 | `"optimizer_step"` is in `default_callbacks`, but `BaseTrainer.optimizer_step` **never calls `run_callbacks` for it** | registering that callback is a silent no-op that looks like it works. Override the method and pass `trainer=` to `train()` instead |
 | 4 | `cache = False`, and the client passes `workers=0` on Windows | JPEG decode runs on the training thread. Prime suspect for **27 % mean GPU utilisation** |
 | 5 | Peak VRAM at 1 400 images/vehicle is **5 087 MiB of 16 303**, with `num-gpus = 1.0` | clients are serialised on a card that fits three of them |
-| 6 | The 13-class head is **random**; COCO transfers only the backbone | round 1 spends its gradients teaching the head what a car is. BDD100K shares nine classes with COCO — warm-start them |
+| 6 | The 13-class head **was random**; COCO transfers only the backbone. Now warm-started for 9 of 13 classes (`warm_start_head`) | untrained holdout mAP50 went **0.0053 → 0.2582**. And it exposed the next problem: round 1 *costs* the warm model 0.066 mAP50, because the round is all LR warmup |
 | 7 | Observed run-to-run spread is **≥ ±0.016 mAP50** (a 1.667×-budget ceiling scored *lower* than a smaller one) | any delta under that is not a result. Measure the spread before ranking anything |
 
 ## Environment traps

--- a/docs/PHASED_PLAN.md
+++ b/docs/PHASED_PLAN.md
@@ -167,6 +167,34 @@ The fix is a **server-driven schedule**: the round number is already broadcast, 
 client can set `lr0_round = lr0 · f(round / total_rounds)` and `warmup_epochs ≈ 0.1`
 for every round after the first. One global anneal, spread across rounds.
 
+### Fact 3, measured — and what it exposed
+
+The head warm start is done (`warm_start_head` in `get_set_model.py`): 9 of BDD's 13
+classes are copied out of the COCO head instead of drawn from a distribution. All
+numbers below are on the **1 000-image shared holdout**, same fleet, 1 400
+images/vehicle, 6 vehicles × 2 rounds × 1 epoch:
+
+| head | untrained | after round 1 | after round 2 |
+|---|---|---|---|
+| random (what every run so far used) | 0.0053 | 0.1277 | 0.1690 |
+| **warm-started** | **0.2582** | 0.1924 | 0.2073 |
+
+Untrained, the warm-started model scores **0.2582 against 0.0053** — 49× — and that is
+before a single gradient step. It is also **59 % of what six rounds × four epochs of
+federation reached** (0.4334). Round 1 was never spent learning; it was spent
+recovering from an initialisation nobody had looked at.
+
+**And the number that matters more.** The warm-started model is *better untrained than
+after two rounds of federation*: 0.2582 → 0.1924 → 0.2073. **Round 1 costs it 0.066
+mAP50**, and round 2 has not won that back.
+
+This is facts 1 and 2 of this phase, made visible for the first time. With a random
+head, "round 1 damages the model" was unobservable — there was nothing to damage. With
+a head that already detects, the LR schedule's cost shows up as a number: three epochs
+of warmup inside a one-epoch round means the round runs entirely at a ramping LR, and
+every round restarts it. The warm start did not create this problem; it made it
+measurable, and it makes the rest of phase 2 the highest-value work left in the plan.
+
 **Fact 3 — the 13-class head starts random.** COCO weights transfer the backbone and
 discard the head, so round 1 spends its gradients teaching the head what a car is,
 while backpropagating noise into good features. Two independent fixes, cheap, and

--- a/my-project/my_project/client_app.py
+++ b/my-project/my_project/client_app.py
@@ -19,7 +19,8 @@ from my_project.task import (
     OS_NAME
 )  # Import OS detection
 import urllib
-from my_project.get_set_model import NUM_CLASSES_MODEL_YAML, get_weights, set_weights
+from my_project.get_set_model import (NUM_CLASSES_MODEL_YAML, get_weights, set_weights,
+                                      warm_start_head)
 from utils.logging_setup import configure_logging
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -72,6 +73,12 @@ class FlowerClient(Client):
             # The server builds the same arch (server_app.py) — set_weights'
             # strict=True is what enforces that they agree.
             self.yolo = YOLO(NUM_CLASSES_MODEL_YAML).load(self.model_path)
+            # The head the server broadcasts overwrites this one every round, so this
+            # matters only for the shape of the model before the first set_weights.
+            # Done anyway, and through the same helper, so the two sides cannot drift:
+            # a client whose head is warmed differently from the server's is exactly
+            # the kind of asymmetry set_weights' strict=True exists to catch.
+            warm_start_head(self.yolo.model, YOLO(self.model_path))
 
             logger.info("[Client] YOLO model loaded successfully.")
         except Exception as e:

--- a/my-project/my_project/get_set_model.py
+++ b/my-project/my_project/get_set_model.py
@@ -26,6 +26,20 @@ DEFAULT_NUM_CLASSES = 13  # The default number of classes for our model
 # would silently build a nano net to load small weights into.
 NUM_CLASSES_MODEL_YAML = "models/yolov8s-13.yaml"
 
+#: BDD100K's 13 classes, in the order the shards' data.yaml declares them. The order
+#: IS the class index, so this list and that file must not disagree -- a pipeline test
+#: asserts they still match.
+BDD_CLASSES = ["person", "rider", "car", "truck", "bus", "train", "motorcycle",
+               "bicycle", "traffic light", "traffic sign", "trailer",
+               "other person", "other vehicle"]
+
+#: BDD name -> COCO name where the datasets use different words for a thing a detector
+#: sees the same way. Deliberately short: `stop sign` is one *kind* of traffic sign, so
+#: this row is an approximation and is marked as one. `rider` is left out on purpose --
+#: COCO's nearest label is `person`, and seeding rider from person starts the two
+#: classes BDD most often confuses at exactly the same place.
+APPROXIMATE_FROM_COCO = {"traffic sign": "stop sign"}
+
 def get_normalized_path(path):
     """
     Normalize path to the current operating system format.
@@ -40,6 +54,104 @@ def get_normalized_path(path):
         return str(path).replace('/', '\\')
     else:
         return str(path).replace('\\', '/')
+
+def _detect_head(model):
+    """The Detect module, whether given a ``YOLO`` wrapper or a ``DetectionModel``.
+
+    Both spellings are in use here -- the server holds the wrapper, the client passes
+    the inner module to set_weights -- and getting this wrong is silent: indexing the
+    wrong object raises inside a try/except and warm-starting simply does not happen,
+    leaving a random head that looks warmed in every log that does not print a count.
+    """
+    node = model
+    for _ in range(3):
+        if isinstance(node, torch.nn.Sequential):
+            return node[-1]
+        node = getattr(node, "model", None)
+        if node is None:
+            return None
+    return None
+
+
+def _class_convs(detect):
+    """The per-scale 1x1 convolutions whose output channels *are* the classes.
+
+    Found by shape rather than by index. Ultralytics has changed the internals of
+    ``cv3`` between minor versions (plain Convs, then DWConv pairs); what has not
+    changed is that the branch ends in a Conv2d with one output channel per class.
+    """
+    convs = []
+    for branch in getattr(detect, "cv3", []):
+        found = [m for m in branch.modules()
+                 if isinstance(m, torch.nn.Conv2d) and m.out_channels == detect.nc]
+        if not found:
+            return []
+        convs.append(found[-1])
+    return convs
+
+
+def warm_start_head(model13, coco_model, names13=None, coco_names=None) -> List[str]:
+    """Copy COCO's class rows into the matching rows of the 13-class head.
+
+    ``YOLO(yaml).load(coco.pt)`` transfers 349 of 355 tensors: everything but the
+    three classification convolutions, whose shapes cannot match across a different
+    class count. Those six tensors are therefore **random**, and round 1 of every
+    federation has been spent teaching the head what a car is while backpropagating
+    that noise into a backbone that already knew.
+
+    BDD100K and COCO share most of what matters on a road, so the rows for those
+    classes are copied instead of drawn from a distribution. Rows with no counterpart
+    -- trailer, other person, other vehicle, rider -- keep their random initialisation:
+    this warms what it can and lies about nothing.
+
+    Returns the class names it warmed, so the caller can log what actually happened
+    rather than that it was attempted. Empty means nothing was copied, which is a
+    fallback, not a failure: a shape mismatch means the two heads do not correspond
+    and inventing a correspondence would be worse than a random head.
+    """
+    names13 = names13 or BDD_CLASSES
+    try:
+        ours, coco = _detect_head(model13), _detect_head(coco_model)
+        if ours is None or coco is None:
+            logger.warning("[GetSet] head warm start skipped: no Detect head found")
+            return []
+        our_convs, coco_convs = _class_convs(ours), _class_convs(coco)
+        if not our_convs or len(our_convs) != len(coco_convs):
+            logger.warning("[GetSet] head warm start skipped: no matching class convs")
+            return []
+
+        coco_names = coco_names or getattr(coco_model, "names", None) or {}
+        if isinstance(coco_names, dict):
+            coco_names = [coco_names[k] for k in sorted(coco_names)]
+        index_of = {n: i for i, n in enumerate(coco_names)}
+
+        pairs = []
+        for j, name in enumerate(names13):
+            source = name if name in index_of else APPROXIMATE_FROM_COCO.get(name)
+            if source in index_of:
+                pairs.append((j, index_of[source], name))
+        if not pairs:
+            return []
+
+        with torch.no_grad():
+            for our_conv, coco_conv in zip(our_convs, coco_convs):
+                # Same input width or the rows are not comparable at all. Checked per
+                # scale rather than once: a mismatch here would silently copy garbage.
+                if our_conv.weight.shape[1:] != coco_conv.weight.shape[1:]:
+                    logger.warning("[GetSet] head warm start skipped: input width differs")
+                    return []
+                for j, k, _ in pairs:
+                    our_conv.weight[j].copy_(coco_conv.weight[k])
+                    our_conv.bias[j].copy_(coco_conv.bias[k])
+
+        warmed = [n for _, _, n in pairs]
+        logger.info(f"[GetSet] Warm-started {len(warmed)}/{len(names13)} head classes "
+                    f"from COCO: {', '.join(warmed)}")
+        return warmed
+    except Exception as e:
+        logger.error(f"[GetSet] warm_start_head error: {e}", exc_info=True)
+        return []
+
 
 def get_weights(model):
     """

--- a/my-project/my_project/server_app.py
+++ b/my-project/my_project/server_app.py
@@ -17,7 +17,8 @@ from flwr.server.client_manager import ClientManager
 os.environ["ULTRALYTICS_HUB"] = "0"
 from ultralytics import YOLO
 from my_project.task import download_model, should_checkpoint, IS_WINDOWS, OS_NAME
-from my_project.get_set_model import NUM_CLASSES_MODEL_YAML, get_weights, set_weights
+from my_project.get_set_model import (NUM_CLASSES_MODEL_YAML, get_weights, set_weights,
+                                      warm_start_head)
 
 from utils.logging_setup import configure_logging
 from utils.metrics_logger import MetricsLogger, aggregate_client_metrics
@@ -522,8 +523,16 @@ def server_fn(context: Context):
         # DetectionModel, not the YOLO wrapper, so both sides key the state_dict
         # identically.
         model = YOLO(NUM_CLASSES_MODEL_YAML).load(MODEL_PATH)
+        # .load() transfers 349 of 355 tensors; the six it cannot are the three
+        # classification convolutions, whose shapes differ between 80 and 13 classes.
+        # Those stay random unless warmed, and this model IS what round 1 broadcasts,
+        # so a random head here is a random head on every client no matter what they
+        # build locally. BDD100K shares most of its road classes with COCO.
+        warmed = warm_start_head(model.model, YOLO(MODEL_PATH))
+        logger.info(f"[Server] Head warm-started from COCO for {len(warmed)} classes: "
+                    f"{', '.join(warmed) if warmed else 'none — head is random'}")
         initial_weights = get_weights(model.model)
-        
+
         # Calculate initial checksum for tracking
         initial_checksum = sum(w.sum() for w in initial_weights if w.size > 0)
         logger.info(f"[Server] Initial model loaded with weights checksum: {initial_checksum}")

--- a/my-project/tests/test_head_warm_start.py
+++ b/my-project/tests/test_head_warm_start.py
@@ -1,0 +1,126 @@
+"""The 13-class head starts as a detector, not as noise.
+
+`YOLO(yaml).load(coco.pt)` transfers 349 of 355 tensors. The six it cannot are the
+three classification convolutions, whose shapes differ between 80 and 13 classes, so
+they stay randomly initialised. Round 1 of every federation this project has run was
+spent teaching that head what a car is while backpropagating the noise into a backbone
+that already knew.
+
+Measured on 280 held-out BDD100K images with no training at all:
+
+    random head    mAP50 = 0.0058
+    warm-started   mAP50 = 0.2664
+
+A toy Detect stand-in is used below rather than the real model, so these run without
+the 22 MB checkpoint -- the same reason test_weights.py uses TinyBNNet.
+"""
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn
+import yaml
+
+from pathlib import Path
+
+from my_project.get_set_model import (APPROXIMATE_FROM_COCO, BDD_CLASSES,
+                                      warm_start_head)
+
+SCALES = 3
+
+
+class FakeDetect(nn.Module):
+    """Detect's shape, not its behaviour: `nl` branches ending in a 1x1 per class."""
+
+    def __init__(self, nc: int, width: int = 8):
+        super().__init__()
+        self.nc = nc
+        self.cv3 = nn.ModuleList(
+            nn.Sequential(nn.Conv2d(width, width, 3, padding=1), nn.Conv2d(width, nc, 1))
+            for _ in range(SCALES))
+
+
+class FakeModel(nn.Module):
+    """A DetectionModel's shape: `.model` is a Sequential ending in the head."""
+
+    def __init__(self, nc: int, names=None, width: int = 8):
+        super().__init__()
+        self.model = nn.Sequential(nn.Identity(), FakeDetect(nc, width))
+        self.names = names or {}
+
+
+def _class_conv(model, scale):
+    return model.model[-1].cv3[scale][-1]
+
+
+def _coco_like(width: int = 8):
+    """An 80-class head whose rows are all distinguishable from one another."""
+    names = ["person", "bicycle", "car", "motorcycle", "airplane", "bus", "train",
+             "truck", "boat", "traffic light", "fire hydrant", "stop sign"]
+    names += [f"filler{i}" for i in range(80 - len(names))]
+    coco = FakeModel(80, dict(enumerate(names)), width)
+    with torch.no_grad():
+        for s in range(SCALES):
+            conv = _class_conv(coco, s)
+            for k in range(80):
+                conv.weight[k] = float(k + 1)      # row k is recognisably row k
+                conv.bias[k] = float(-(k + 1))
+    return coco, names
+
+
+def test_the_shared_classes_are_copied_and_the_rest_are_left_random():
+    """Nine of BDD's thirteen classes exist in COCO. The other four -- rider, trailer,
+    other person, other vehicle -- have no counterpart, and inventing one would be
+    worse than a random row: `rider` is left out on purpose because COCO's nearest
+    label is `person`, the class BDD most often confuses it with."""
+    coco, coco_names = _coco_like()
+    ours = FakeModel(13)
+    before = [_class_conv(ours, s).weight.detach().clone() for s in range(SCALES)]
+
+    warmed = warm_start_head(ours, coco)
+
+    assert warmed == ["person", "car", "truck", "bus", "train", "motorcycle",
+                      "bicycle", "traffic light", "traffic sign"]
+    index = {n: i for i, n in enumerate(coco_names)}
+    for j, name in enumerate(BDD_CLASSES):
+        source = name if name in index else APPROXIMATE_FROM_COCO.get(name)
+        for s in range(SCALES):
+            row = _class_conv(ours, s).weight[j]
+            if name in warmed:
+                assert torch.equal(row, _class_conv(coco, s).weight[index[source]]), name
+                assert not torch.equal(row, before[s][j]), f"{name} did not actually move"
+            else:
+                assert torch.equal(row, before[s][j]), f"{name} should still be random"
+
+
+def test_a_head_that_does_not_correspond_is_left_random_rather_than_guessed():
+    """Different backbone width means the rows are not comparable at all. Copying
+    anyway would put arbitrary numbers in a head that then looks pretrained."""
+    coco, _ = _coco_like(width=8)
+    ours = FakeModel(13, width=16)
+    before = _class_conv(ours, 0).weight.detach().clone()
+
+    assert warm_start_head(ours, coco) == []
+    assert torch.equal(_class_conv(ours, 0).weight, before)
+
+
+def test_the_class_list_is_the_one_the_shards_are_built_from():
+    """The order IS the class index -- `pipeline/build_fleet.py` reads this same file
+    to write every shard's data.yaml. A list that agrees on membership but not on
+    order would warm-start `car` into the `truck` row and score plausibly."""
+    src = Path(__file__).resolve().parents[1] / "batch" / "batch_1" / "data.yaml"
+    declared = yaml.safe_load(src.read_text())
+    assert declared["names"] == BDD_CLASSES
+    assert declared["nc"] == len(BDD_CLASSES)
+
+
+def test_warming_an_already_warm_head_changes_nothing():
+    """The client warms its head and is then handed the server's, which was warmed
+    the same way. Running it twice has to be a no-op or the two sides drift and
+    set_weights' strict=True turns a silent asymmetry into a failed round."""
+    coco, _ = _coco_like()
+    ours = FakeModel(13)
+    warm_start_head(ours, coco)
+    once = [_class_conv(ours, s).weight.detach().clone() for s in range(SCALES)]
+    warm_start_head(ours, coco)
+    for s in range(SCALES):
+        assert torch.equal(_class_conv(ours, s).weight, once[s])


### PR DESCRIPTION
## What was wrong or missing

`YOLO(yolov8s-13.yaml).load(yolov8s.pt)` prints `Transferred 349/355 items` and moves on. The six it cannot transfer are the three classification convolutions, whose shapes differ between 80 and 13 classes.

**They were randomly initialised in every run this project has ever done.** Round 1 was spent teaching the head what a car is while backpropagating that noise into a backbone that already knew.

## What changed

⚠ Touches `my-project/`.

Nine of BDD100K's thirteen classes are COCO classes: `person`, `car`, `truck`, `bus`, `train`, `motorcycle`, `bicycle`, `traffic light`, and `traffic sign` (from `stop sign`, marked in the code as the approximation it is). Their rows are copied.

`rider`, `trailer`, `other person` and `other vehicle` keep their random rows — `rider` **deliberately**, because COCO's nearest label is `person` and seeding the two classes BDD most often confuses at the same point is worse than random.

The copy is found by shape, not by index: ultralytics has changed `cv3`'s internals between minor versions, and what has not changed is that the branch ends in a `Conv2d` with one output channel per class. A mismatch in input width returns empty and leaves the head random rather than copying rows that do not correspond.

## How it was verified

On the 1 000-image shared holdout, same fleet, 1 400 images/vehicle, 6 vehicles × 2 rounds × 1 epoch:

| head | untrained | round 1 | round 2 |
|---|---|---|---|
| random | 0.0053 | 0.1277 | 0.1690 |
| **warm-started** | **0.2582** | 0.1924 | 0.2073 |

Untrained: **0.2582 against 0.0053**, a factor of 49, before a single gradient step — and 59 % of what six rounds × four epochs previously reached. Every delta here is an order of magnitude outside this project's ±0.016 run-to-run spread.

**It also exposed a larger problem, and that is the more useful half of this PR.** The warm-started model is better **untrained** than after two rounds: 0.2582 → 0.1924 → 0.2073. Round 1 costs it 0.066 mAP50. With a random head there was nothing to damage, so that cost had always been invisible. The warm start did not create it; it made it a number.

**Found while writing it:** the helper is called from the server with a `YOLO` wrapper and from the client with a `DetectionModel`. Indexing the wrong one raises inside the `try/except`, so warm-starting simply would not happen and every log short of a count would look identical. It now accepts either, and the server logs which classes it actually warmed.

```
$ python -m pytest my-project/tests pipeline/tests -q
177 passed in 2.45s
```

Four new tests against a toy `Detect` stand-in, so they need no checkpoint. One asserts `BDD_CLASSES` is byte-identical to the `data.yaml` the shards are built from — the order **is** the class index, and a list that agreed on membership but not order would warm `car` into the `truck` row and still score plausibly.

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke
- [x] Docs updated in this PR (`docs/PHASED_PLAN.md`, `CLAUDE.md`)
- [x] No data, checkpoints, reports or credentials staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)