### PR TITLE
exp(schedule): one LR anneal across the run — measured, and NOT adopted [DO NOT MERGE]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,8 @@ to be wrong quietly.
 
 | | Fact | Why it matters |
 |---|---|---|
-| 1 | `warmup_epochs = 3.0` against `local_epochs = 4` | three of every four epochs are warmup; every client ends a round worse than the aggregate it started from |
-| 2 | `lrf = 0.01` decays **within** the round, and each round calls `train()` fresh at `lr0` | six rounds is six independent anneals, never one. The fleet never anneals globally |
+| 1 | `warmup_epochs = 3.0`, but `_get_warmup_iterations` clamps it to `epochs - 1` | at `local_epochs = 4`, three of every four epochs are warmup. At `local_epochs = 1` there is **no warmup at all** — so a bad round-1 result there is the LR *level*, not warmup. Do not merge the two |
+| 2 | `lrf = 0.01` decays **within** the round, and each round calls `train()` fresh at `lr0` | six rounds is six independent anneals. **Tried and rejected:** one anneal across the run measured −0.0079 mAP50 at 6×1 epoch, negative at all six rounds. Branch `feat/one-lr-anneal-across-rounds`, unmerged. Untested at `local_epochs = 4`, which is what the argument is really about |
 | 3 | `"optimizer_step"` is in `default_callbacks`, but `BaseTrainer.optimizer_step` **never calls `run_callbacks` for it** | registering that callback is a silent no-op that looks like it works. Override the method and pass `trainer=` to `train()` instead |
 | 4 | `cache = False`, and the client passes `workers=0` on Windows | JPEG decode runs on the training thread. Prime suspect for **27 % mean GPU utilisation** |
 | 5 | Peak VRAM at 1 400 images/vehicle is **5 087 MiB of 16 303**, with `num-gpus = 1.0` | clients are serialised on a card that fits three of them |

--- a/docs/BACKLOG_100.md
+++ b/docs/BACKLOG_100.md
@@ -114,7 +114,7 @@ See [`FL_TECHNIQUES.md`](FL_TECHNIQUES.md) — Flower already ships 24 strategie
 
 | # | Feature | P |
 |---|---|---|
-| 80 | MLflow logging wired for real (module exists, nothing calls it in anger) | P1 |
+| 80 | MLflow logging wired for real (module exists, nothing calls it in anger) | ✅ 2026-08-16 — sqlite backend, one experiment, runner calls the sink |
 | 81 | Run comparison report: N runs, one table, deltas | P1 |
 | 82 | Alerting: notify on failure or on a plateau | P2 |
 | 83 | Cost accounting per run — kWh, and money at a configured tariff | P2 |
@@ -128,13 +128,13 @@ See [`FL_TECHNIQUES.md`](FL_TECHNIQUES.md) — Flower already ships 24 strategie
 
 | # | Feature | P |
 |---|---|---|
-| 89 | Measure real per-client VRAM and pack clients concurrently where they fit | P1 |
+| 89 | Measure real per-client VRAM and pack clients concurrently where they fit | ✅ 2026-08-16 — `--gpu-fraction 0.33`, 1.94x, 43 % less energy |
 | 90 | AMP / channels-last / `torch.compile` benchmark at fixed accuracy | P2 |
-| 91 | Cache the dataset scan across rounds — Ultralytics rescans every time | P2 |
+| 91 | Cache the dataset scan across rounds — Ultralytics rescans every time | P2 — but phase 0 caps the whole per-round fixed cost at 0.3 % |
 | 92 | Persistent client actors so the model is not reloaded per round | P2 |
 | 93 | Multi-GPU / multi-node once the fleet outgrows one card | P3 |
 | 94 | Mixed-resolution training: small images early, full later | P3 |
-| 95 | Profile the round to find the non-training overhead | P2 |
+| 95 | Profile the round to find the non-training overhead | ✅ 2026-08-16 — `pipeline/profile.py`; 99.1 % of wall clock is inside a client |
 
 ## G. Reliability, process, docs (96–100)
 
@@ -153,7 +153,7 @@ installed ultralytics 8.4.115 rather than assumed.
 
 | # | Feature | P |
 |---|---|---|
-| 101 | **Warm-start the 13-class head from the COCO head rows** for the nine classes BDD100K shares with COCO, instead of random init ⚠ | P1 |
+| 101 | **Warm-start the 13-class head from the COCO head rows** for the nine classes BDD100K shares with COCO, instead of random init ⚠ | ✅ 2026-08-16 — untrained holdout mAP50 0.0053 → 0.2582 |
 | 102 | **Server-driven LR schedule across rounds** — today `lrf` anneals *within* each round and the next round restarts at `lr0`, so the fleet never anneals globally ⚠ | P1 |
 | 103 | **`cache="ram"` and the Windows dataloader path** — decode currently runs on the training thread (`workers=0`), the prime suspect behind 27 % GPU utilisation ⚠ | P1 |
 | 104 | **True FedProx via a `DetectionTrainer.optimizer_step` override.** Note: the `"optimizer_step"` *callback* is registered but never fired — using it would be a silent no-op ⚠ | P1 |

--- a/docs/PHASED_PLAN.md
+++ b/docs/PHASED_PLAN.md
@@ -150,11 +150,54 @@ warmup_epochs = 3.0   lr0 = 0.01   lrf = 0.01   cos_lr = False
 close_mosaic  = 10    mosaic = 1.0   freeze = None   patience = 100   nbs = 64
 ```
 
-**Fact 1 — three of every four epochs are warmup.** `local_epochs = 4` against
-`warmup_epochs = 3.0` means the LR ramp never finishes. The Metrics tab already shows
+**Fact 1 — warmup is clamped to `epochs - 1`, which is not what "warmup_epochs = 3.0"
+suggests.** Read from `BaseTrainer._get_warmup_iterations` in 8.4.115:
+
+```python
+warmup_epochs = min(self.args.warmup_epochs, max(self.epochs - 1, 0))
+return round(warmup_epochs * num_batches) if warmup_epochs > 0 else 0
+```
+
+So at `local_epochs = 4` the reference run really did spend three of four epochs in
+warmup — the fact below stands for that configuration. But at **`local_epochs = 1`
+there is no warmup at all**, and every measurement in this session ran at 1. The
+round-1 damage recorded under fact 3 is therefore *not* a warmup effect: it is the
+learning-rate **level**, `lr0 = 0.01` applied for a full epoch to a model that already
+detects. Two different problems that the phrase "three of every four epochs are warmup"
+would have merged.
+
+`local_epochs = 4` against `warmup_epochs = 3.0` means the LR ramp never finishes. The Metrics tab already shows
 box, cls **and** dfl rising across the four epochs of every round: each client ends the
 round worse than the aggregate it started from, and FedAvg then averages six models
 that each went slightly backwards.
+
+### Fact 2, measured — and it did not hold
+
+One anneal across the run was implemented (`round_lr()` on
+`feat/one-lr-anneal-across-rounds`): round *r* gets the slice [(r−1)/R, r/R] of a single
+linear decay, so round 1 starts at `lr0` and round 6 runs at 0.00175 instead of 0.01
+again. Both arms: same warm-started head, same fleet, 1 400 images/vehicle, 6 vehicles ×
+6 rounds × 1 epoch, `--gpu-fraction 0.33`.
+
+| round | 1 | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|---|
+| one anneal | 0.1906 | 0.2100 | 0.2413 | 0.2570 | 0.2774 | 0.2906 |
+| restart each round (today) | 0.1943 | 0.2145 | 0.2496 | 0.2718 | 0.2833 | **0.2985** |
+| Δ | −0.0037 | −0.0045 | −0.0083 | −0.0148 | −0.0059 | −0.0079 |
+
+**No measured improvement — and the sign is negative at every one of the six rounds.**
+The final gap, −0.0079, is inside the ±0.016 spread, so the honest reading is "no
+difference"; but six of six negative is not what a real win looks like either.
+
+**Not adopted.** The code and its tests are on the branch, unmerged. It adds a
+server→client config pair and a schedule function to buy nothing measurable, and this
+repo's rule is that machinery needs a reason.
+
+**What the measurement does not cover, stated so nobody re-reads this as settled:** both
+arms ran `local_epochs = 1`. At one epoch ultralytics' `LambdaLR` steps once, so each
+round is a *constant* LR — today's behaviour is a flat 0.01 every round, and the anneal
+made it a decaying staircase. The plan's argument is really about `local_epochs = 4`,
+where a round has internal decay to restart. That test costs 4× and has not been run.
 
 **Fact 2 — the LR schedule restarts every round.** `lrf = 0.01` decays the LR to 1 % of
 `lr0` *within* the round, then the next round starts a fresh `YOLO.train()` at `lr0`

--- a/my-project/my_project/client_app.py
+++ b/my-project/my_project/client_app.py
@@ -35,6 +35,41 @@ DEFAULT_BATCH_ID_RANGE = (1, 10)
 # images before stepping the optimizer (ultralytics default `nbs`).
 NOMINAL_BATCH_SIZE = 64
 DEFAULT_IMAGE_SIZE = 640
+# Ultralytics' own defaults, restated here because the whole point below is to slice
+# them across rounds rather than replay them inside every one.
+LR0 = 0.01
+LRF = 0.01
+
+
+def round_lr(server_round: int, num_rounds: int, lr0: float = LR0, lrf: float = LRF):
+    """One learning-rate anneal spread over the whole run, not one per round.
+
+    Ultralytics decays lr0 to ``lr0 * lrf`` **within** a call to train(), and every
+    round calls train() fresh. Six rounds was therefore six independent anneals from
+    full LR, and the fleet never got the low-LR consolidation phase that makes the last
+    epochs of a centralised run count -- a structural explanation for the gap to the
+    centralised ceiling that has nothing to do with federation.
+
+    This hands round r the slice [(r-1)/R, r/R] of a single linear decay: it starts
+    where the previous round ended and ends where the next one starts. Round 1 still
+    runs at full lr0, as a centralised run does; the last round runs near lr0*lrf.
+
+    Returns ``(lr0_round, lrf_round)``. ``lrf_round`` is a *ratio*, because that is
+    what ultralytics wants: the fraction of this round's lr0 to finish at.
+
+        >>> [round(x, 4) for x in round_lr(1, 6)]
+        [0.01, 0.8351]
+        >>> [round(x, 5) for x in round_lr(6, 6)]
+        [0.00175, 0.0566]
+    """
+    total = max(int(num_rounds), 1)
+    r = min(max(int(server_round), 1), total)
+
+    def frac(p):                       # linear, matching ultralytics' cos_lr=False
+        return (1.0 - p) * (1.0 - lrf) + lrf
+
+    start, end = frac((r - 1) / total), frac(r / total)
+    return lr0 * start, end / start
 
 class FlowerClient(Client):
 
@@ -221,12 +256,23 @@ class FlowerClient(Client):
                     f"optimizer step. This round will not change the weights. Raise "
                     f"local_epochs or lower the batch size."
                 )
+            server_round = int(ins.config.get("server_round", 1) or 1)
+            num_rounds = int(ins.config.get("num_rounds", 1) or 1)
+            lr0_round, lrf_round = round_lr(server_round, num_rounds)
+            logger.info(f"[Client] Round {server_round}/{num_rounds} learning rate: "
+                        f"lr0={lr0_round:.5f} lrf={lrf_round:.4f} "
+                        f"(ends at {lr0_round * lrf_round:.5f})")
             results = self.yolo.train(
                 data=data_yaml_path,
                 epochs=local_epochs,
                 imgsz=DEFAULT_IMAGE_SIZE,
                 device=self.device,
                 batch=batch,
+                # One anneal across the run. See round_lr: without this, every round
+                # restarted at lr0 and decayed inside itself, so the fleet repeated the
+                # first third of a schedule six times and never reached the last third.
+                lr0=lr0_round,
+                lrf=lrf_round,
                 verbose=False,
                 # Ultralytics defaults to 8. Inside a Ray actor on Windows that is a
                 # deadlock, not a slowdown — spawned dataloader children never join.

--- a/my-project/my_project/server_app.py
+++ b/my-project/my_project/server_app.py
@@ -541,8 +541,13 @@ def server_fn(context: Context):
         raise RuntimeError("Server cannot start without a valid YOLO model.") from e
 
     # Push local_epochs to every client each round via config callbacks.
+    # `num_rounds` travels too, because the client cannot otherwise know where in the
+    # run it is: without the denominator, "round 3" says nothing about how much of the
+    # learning-rate anneal belongs to this round. Both are per-*run* constants, so
+    # sharing one FitIns across clients is safe here in a way it was not for batch_id.
     def fit_config_fn(server_round: int) -> Dict[str, Scalar]:
-        return {"local_epochs": local_epochs, "server_round": server_round}
+        return {"local_epochs": local_epochs, "server_round": server_round,
+                "num_rounds": num_rounds}
 
     # Build the strategy through the registry: the mixin carries this project's
     # behaviour, the named Flower strategy carries the aggregation.

--- a/my-project/tests/test_round_schedule.py
+++ b/my-project/tests/test_round_schedule.py
@@ -1,0 +1,56 @@
+"""One learning-rate anneal across the run, not one per round.
+
+Ultralytics decays lr0 to `lr0 * lrf` inside a call to train(), and every round calls
+train() fresh. Six rounds was six independent anneals from full LR, so the fleet
+replayed the first slice of a schedule six times and never reached the low-LR
+consolidation phase that makes the last epochs of a centralised run count.
+"""
+import pytest
+
+from my_project.client_app import LR0, LRF, round_lr
+
+
+def test_each_round_starts_where_the_previous_one_ended():
+    """That is what makes it one schedule rather than six. If the ends and starts do
+    not meet, the LR jumps between rounds and the anneal is decorative."""
+    rounds = 6
+    for r in range(1, rounds):
+        lr0, lrf = round_lr(r, rounds)
+        next_lr0, _ = round_lr(r + 1, rounds)
+        assert lr0 * lrf == pytest.approx(next_lr0, rel=1e-9), f"gap after round {r}"
+
+
+def test_the_run_spans_the_whole_schedule_and_never_restarts_it():
+    """Round 1 at full lr0, as a centralised run starts; the last round near lr0*lrf,
+    which is where a centralised run finishes. Before this, every round started at
+    0.01 -- the fleet's sixth round trained as aggressively as its first."""
+    rounds = 6
+    first_lr0, _ = round_lr(1, rounds)
+    last_lr0, last_lrf = round_lr(rounds, rounds)
+
+    assert first_lr0 == pytest.approx(LR0)
+    assert last_lr0 * last_lrf == pytest.approx(LR0 * LRF, rel=1e-9)
+
+    starts = [round_lr(r, rounds)[0] for r in range(1, rounds + 1)]
+    assert starts == sorted(starts, reverse=True), "the LR must fall across the run"
+    assert len(set(starts)) == rounds, "a repeated lr0 is a restarted schedule"
+
+
+def test_a_single_round_run_is_a_whole_schedule_by_itself():
+    """The demo profile and the CI smoke both run one or two rounds. A schedule that
+    only makes sense at six would leave those training at a fraction of lr0 for no
+    reason anyone could see in the config."""
+    lr0, lrf = round_lr(1, 1)
+    assert lr0 == pytest.approx(LR0)
+    assert lr0 * lrf == pytest.approx(LR0 * LRF, rel=1e-9)
+
+
+def test_a_round_number_outside_the_run_is_clamped_not_extrapolated():
+    """A restarted or resumed federation can report a round beyond num_rounds. The
+    linear factor goes negative past the end, and a negative learning rate is an
+    optimiser walking uphill -- with nothing in any log that would say so."""
+    assert round_lr(9, 6) == round_lr(6, 6)
+    assert round_lr(0, 6) == round_lr(1, 6)
+    for r in (-3, 0, 1, 5, 6, 99):
+        lr0, lrf = round_lr(r, 6)
+        assert lr0 > 0 and lrf > 0


### PR DESCRIPTION
## ⚠ Do not merge

Draft on purpose. This is an experiment record, not a proposal. The implementation is here so the next session does not rebuild it to test the one configuration this did not cover; the **result** lives in `docs/PHASED_PLAN.md` and `CLAUDE.md`, which is where it has to survive.

## What was wrong or missing

Phase 2, fact 2. `lrf` decays `lr0` to 1 % **within** a call to `train()`, and every round calls `train()` fresh — so six rounds was six independent anneals, and the fleet never got the low-LR consolidation that makes the last epochs of a centralised run count. The plan named this a structural explanation for part of the 15 % gap to the ceiling.

## What changed

`round_lr()` hands round *r* the slice `[(r-1)/R, r/R]` of a single linear decay: it starts where the previous round ended and ends where the next one starts, so the concatenation is one continuous schedule rather than the staircase the phase-2 prompt described (`lrf = 1.0` within the round). Round 1 at `lr0 = 0.01` as a centralised run starts; round 6 at 0.00175.

```
round 1: lr0=0.01000 -> 0.00835      round 4: lr0=0.00505 -> 0.00340
round 2: lr0=0.00835 -> 0.00670      round 5: lr0=0.00340 -> 0.00175
round 3: lr0=0.00670 -> 0.00505      round 6: lr0=0.00175 -> 0.00010
```

## How it was verified

Both arms: same warm-started head, same fleet, 1 400 images/vehicle, 6 vehicles × 6 rounds × 1 epoch, `--gpu-fraction 0.33`, 1 000-image holdout.

| round | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| one anneal | 0.1906 | 0.2100 | 0.2413 | 0.2570 | 0.2774 | 0.2906 |
| restart each round (today) | 0.1943 | 0.2145 | 0.2496 | 0.2718 | 0.2833 | **0.2985** |
| Δ | −0.0037 | −0.0045 | −0.0083 | −0.0148 | −0.0059 | −0.0079 |

**No measured improvement.** −0.0079 is inside this project's ±0.016 spread, so the honest reading is "no difference" — but negative at **six of six** rounds is not what a real win looks like either. It buys a server→client config pair and a schedule function for nothing measurable, and machinery needs a reason.

**What this does NOT settle**, stated so it is not re-read as closed: both arms ran `local_epochs = 1`. At one epoch ultralytics' `LambdaLR` steps once, so a round is a **constant** LR — today's behaviour is a flat 0.01 every round and the anneal made it a decaying staircase. The plan's argument is about `local_epochs = 4`, where a round has internal decay to restart. That test costs 4× and was not run.

**Also corrected here**, because it changes what phase 2 should do rather than how it is worded: `BaseTrainer._get_warmup_iterations` clamps warmup to `epochs - 1`. At `local_epochs = 4` the reference run really did spend three of four epochs warming up, but at `local_epochs = 1` there is **no warmup at all** — and every measurement in this session ran at 1. The round-1 damage recorded against the head warm start (#51) is therefore the learning-rate **level**, not warmup.

```
$ python -m pytest my-project/tests pipeline/tests -q
181 passed in 3.36s
```

Four new tests on the schedule itself: rounds meeting end-to-start, the run spanning the whole schedule, a single-round run still being a whole schedule, and a round number past the end being clamped rather than extrapolated into a **negative learning rate**.

## Checklist

- [x] A test fails without this change
- [x] Full suite green
- [ ] CI green, including the federation smoke
- [x] Docs updated in this PR (`docs/PHASED_PLAN.md`, `CLAUDE.md` — both record the rejection)
- [x] No data, checkpoints, reports or credentials staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)